### PR TITLE
update examples sentence and include LV minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 This repo contains necessary C++ code and support VIs to implement a gRPC server in LabVIEW.
 
-eexample/ExampleQueryServer.vi with query_server.proto defines a simple query service example that can be used for a variety of purposes.  
+Open `examples/query_server/Query Server.lvproj` for examples on creating a query server. `/examples/query_server/Protos/query_server.proto` defines a simple query service example that can be used for a variety of purposes.
 
 You can either use the service as defined to implement a generic server via gPRC or use the implementation
 as a pattern to implement a gRPC service of your design.
 
 The project supports Windows, Linux, and Linux RT.
+
+## Minimum Compatible LabVIEW Version
+
+LabVIEW source is saved with __LabVIEW 2019__.
 
 ## Note: This project is not yet complete
 * Not all .proto data types are supported
@@ -24,7 +28,6 @@ Step-by-step examples can be found in the [Creating a Server](docs/ServerCreatio
 
 Example servers are located in the examples foldes in the releases.
 * QueryServer - Example server which implements a Query / Invoke / Event API
-* 
 
 The examples include a python client that can be used to communicate with the example servers.
 


### PR DESCRIPTION
Talking with @ccifra , we agreed that the sentence mentioning the examples at the top of the README was out of date, and that minimum version of LabVIEW supported was missing. Adding it now.