### PR TITLE
Initial example setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,5 +47,5 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
 
 (taken from [developercertificate.org](https://developercertificate.org/))
 
-See [LICENSE](https://github.com/ni/<reponame>/blob/master/LICENSE)
+See [LICENSE](https://github.com/ni/grpc-labview/blob/master/LICENSE)
 for details about how labview-grpc-query-server is licensed.

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ See [Certificates](docs/Certificates.md) for more information.
 To build the binaries for the scripting tool or the gRPC server see [Building](docs/Building.md) for instructions.
 
 ## Contributing
-Contributions to grpc-labview are welcome from all. See [Contributing](Contributing.md) for instructions.
+Contributions to grpc-labview are welcome from all. See [Contributing](CONTRIBUTING.md) for instructions.
 

--- a/docs/ServerCreation.md
+++ b/docs/ServerCreation.md
@@ -58,4 +58,4 @@ In you method implementation to must use the Get RPC Method Get Input VI to get 
 * Fill in the path to certificate files if a TLS connection is required, see the section on SSL/TLS Support below for more imformation
 * Run the `Main.vi`
 
-![RPC Server Main](docs/images/server-main.png "Server Main")
+![RPC Server Main](images/server-main.png "Server Main")

--- a/examples/query_server/Clients/python/queryserver.py
+++ b/examples/query_server/Clients/python/queryserver.py
@@ -11,8 +11,9 @@
 #   if you are using anaconda
 #     > conda install grpcio-tools
 #
-# Generate the python API from the gRPC definition (.ptoto) files
+# Generate the python API from the gRPC definition (.proto) files
 #   > python -m grpc_tools.protoc -I.. --python_out=. --grpc_python_out=. ../query_server.proto
+#   > python -m grpc_tools.protoc -I../../Protos --python_out=. --grpc_python_out=. ../../Protos/query_server.proto
 #
 # Update the server address in this file to match where the LabVIEW server is running
 #

--- a/examples/query_server/Query Server.lvproj
+++ b/examples/query_server/Query Server.lvproj
@@ -13,7 +13,7 @@
 		<Property Name="specify.custom.address" Type="Bool">false</Property>
 		<Item Name="Clients" Type="Folder">
 			<Item Name="Python client" Type="Folder">
-				<Item Name="queryserver.py" Type="Document" URL="../Clients/Python client/queryserver.py"/>
+				<Item Name="queryserver.py" Type="Document" URL="../Clients/python/queryserver.py"/>
 			</Item>
 		</Item>
 		<Item Name="Protos" Type="Folder">


### PR DESCRIPTION
I'm not sure what the minimum PR size is, these are all fairly trivial changes, but some of them are specific to user-facing documentation that are basically the first thing I found here (broken links etc).

Also, to run the example, I followed the steps below - I can write these up somewhere if desired, but I didn't add here because I might have just done it wrongly/badly...

- Install python packages following comments in queryserver.py
- Generate python proto bits using modified command line (relative paths changed over time?) (this edit should perhaps be adjusted to either list only the new line, or indicate some detail about the previous line, if you want to consider this PR let me know which and I'll change it)
- Extract the appropriate (32/64 bit) dll from the releases zip -> package (as zip). I see this file is generated by CMake, perhaps I should instead have built the library myself. \*1
- Place at <grpc-labview>\examples\query_server\Servers\Query Server\gRPC lvSupport\dlls\labview_grpc_server.dll

Then more for runtime/testing
- Set "server address" to 0.0.0.0:50051 \*2
- Can observe different heartbeat counts for async/sync (guess wait timing or something?)
- Can also connect using BloomRPC to the LabVIEW server.

\*1 The build instructions are very clear, thank you! When I followed them carefully, I had no problems building.
If this is the intended behaviour, maybe the readme (or some other file, I can write something for the example specifically if desired) could indicate that users should build the library and copy the file as required before attempting to run the example? (I tracked down the error (i.e. no DLL) when running the LabVIEW server using DETT).

\*2 This is shown in the images in docs, also "ServerCreation.md" describes this field as the "address filter". Also, the documentation at https://grpc.io/docs/languages/cpp/basics/ has a string with the name "server_address" and the same value, passed to AddListeningPort, so I suppose this is a standard label for gRPC. 
However, my initial attempt was to place things like "localhost:12345" here, and then "localhost" or "localhost:50051" after I saw 50051 was the port given in the python script (this works, since I was testing locally, but it didn't work because I understood it correctly, just because I happened to be testing locally).
Maybe at this point in time, you'd rather not spend time with this type of thing, but for a general release maybe this is an unusual name for LabVIEW users less experienced with gRPC documentation? (Address Filter describes the purpose much more clearly for me).