### PR TITLE
Remove infinite loop that can occur

### DIFF
--- a/src/message_element_metadata_owner.cc
+++ b/src/message_element_metadata_owner.cc
@@ -78,7 +78,7 @@ namespace grpc_labview {
         {
             return 0;
         }
-        auto multiple = ClusterElementSize(type, repeated);    
+        auto multiple = ClusterElementSize(type, repeated);
         int remainder = abs(clusterOffset) % multiple;
         if (remainder == 0)
         {
@@ -95,7 +95,7 @@ namespace grpc_labview {
     void MessageElementMetadataOwner::RegisterMetadata(std::shared_ptr<MessageMetadata> requestMetadata)
     {
         std::lock_guard<std::mutex> lock(_mutex);
-        
+
         _registeredMessageMetadata.insert({requestMetadata->messageName, requestMetadata});
     }
 
@@ -118,26 +118,20 @@ namespace grpc_labview {
         if (metadata->clusterSize != 0)
         {
             return;
-        }    
+        }
         int clusterOffset = 0;
         for (auto element: metadata->_elements)
         {
             auto elementType = element->type;
             auto nestedElement = element;
-            while (elementType == LVMessageMetadataType::MessageValue)
-            {
-                auto nestedMetadata = FindMetadata(element->embeddedMessageName);
-                auto nestedElement = nestedMetadata->_elements.front();
-                elementType = nestedElement->type;
-            }    
             clusterOffset = AlignClusterOffset(clusterOffset, element->type, element->isRepeated);
             element->clusterOffset = clusterOffset;
             if (element->type == LVMessageMetadataType::MessageValue)
-            {                
+            {
                 auto nestedMetadata = FindMetadata(element->embeddedMessageName);
                 UpdateMetadataClusterLayout(nestedMetadata);
                 if (element->isRepeated)
-                {                
+                {
                     clusterOffset += ClusterElementSize(element->type, element->isRepeated);
                 }
                 else


### PR DESCRIPTION
Without this change, LabVIEW hangs in `Create Client.vi > CompleteMetadataRegistration.vi > CompleteMetadataRegistration` if messages are nested deeper than 2 levels. For example, this works...

```
message Ego {
  int32 x = 1;
}

message GoProResponse {
  Ego ego = 1;
}
```

But this doesn't...

```
message Quantity {
  float value = 1;
  string units = 2;
}

message Ego {
  Quantity x = 1;
}

message GoProResponse {
  Ego ego = 1;
}
```

Debugging the dll points to the removed loop as the culprit, and it doesn't appear to do anything. When I removed it, built, and streamed back my deeply nested message response, everything worked.