### PR TITLE
Fix crash with multiple grpc service starts

### DIFF
--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -101,6 +101,8 @@ namespace grpc_labview
         delete serverStarted;
         if (result == -1)
         {
+            // If we weren't able to start the gRPC server then the _runThread has nothing to do.
+            // So do an immediate join on the thread.
             _runThread->join();
         }
         return result;


### PR DESCRIPTION
Fix for Issue #35 

The issue was that if we were to start multiple gRPC services on the same port, the second service would return an error from the call to [LabVIEWgRPCServer::Run()](https://github.com/ni/grpc-labview/blob/9d93b02bc5fd39c315c1014eeeabaaafb456d8f6/src/grpc_server.cc#L93) and the generated code in LV would detect the error and call [LVStopServer](https://github.com/ni/grpc-labview/blob/9d93b02bc5fd39c315c1014eeeabaaafb456d8f6/src/grpc_interop.cc#L132). This call tries to stop the LabVIEWgRPCServer and delete the server object. 

In the [LabVIEWgRPCServer::StopServer](https://github.com/ni/grpc-labview/blob/9d93b02bc5fd39c315c1014eeeabaaafb456d8f6/src/grpc_server.cc#L223) we don't do anything if we had never actually initialized the server including not calling join() on the _runThread. As a result, when we try to delete the server object it calls the destructor on the _runThread which [ends up calling std::terminate()](https://en.cppreference.com/w/cpp/thread/thread/~thread) if the thread is still joinable leading to a crash in LV.

To fix this issue I changed the code to do an immediate join in the `LabVIEWgRPCServer::Run()` call if we detect that we weren't able to start the gRPC server since the _runThread will have nothing to do in that case.