### PR TITLE
Changes to cleanup grpc connections on aborting VIs

### DIFF
--- a/src/grpc_client.cc
+++ b/src/grpc_client.cc
@@ -189,9 +189,9 @@ int32_t ClientCleanUpProc(grpc_labview::gRPCid* clientId)
         return -1;
     }
 
-    for (auto activeclientCall = client->ActiveClientCalls.begin(); activeclientCall != client->ActiveClientCalls.end(); activeclientCall++)
+    for (auto activeClientCall = client->ActiveClientCalls.begin(); activeClientCall != client->ActiveClientCalls.end(); activeClientCall++)
     {
-        (*activeclientCall)->_context.TryCancel();
+        (*activeClientCall)->_context.TryCancel();
     }
     return CloseClient(clientId);
 }

--- a/src/grpc_client.h
+++ b/src/grpc_client.h
@@ -10,12 +10,14 @@
 #include <lv_message.h>
 #include <grpcpp/impl/codegen/sync_stream.h>
 #include <future>
+#include <list>
 
 namespace grpc_labview 
 {
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
     class LVMessage;
+    class ClientCall;
 
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
@@ -27,6 +29,7 @@ namespace grpc_labview
 
     public:
         std::shared_ptr<grpc::Channel> Channel;
+        std::list<ClientCall*> ActiveClientCalls;
     };
 
     //---------------------------------------------------------------------

--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -92,13 +92,16 @@ namespace grpc_labview
     }
 }
 
+int32_t ServerCleanupProc(grpc_labview::gRPCid* serverId);
+
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t LVCreateServer(grpc_labview::gRPCid** id)
 {
     grpc_labview::InitCallbacks();
     auto server = new grpc_labview::LabVIEWgRPCServer();
-    *id = server;   
+    *id = server;
+    grpc_labview::RegisterCleanupProc(ServerCleanupProc, server);
     return 0;
 }
 
@@ -137,8 +140,15 @@ LIBRARY_EXPORT int32_t LVStopServer(grpc_labview::gRPCid** id)
         return -1;
     }
     server->StopServer();
+
+    grpc_labview::DeregisterCleanupProc(ServerCleanupProc, *id);
     delete server;
     return 0;
+}
+
+int32_t ServerCleanupProc(grpc_labview::gRPCid* serverId)
+{
+    return LVStopServer(&serverId);
 }
 
 //---------------------------------------------------------------------
@@ -255,7 +265,7 @@ LIBRARY_EXPORT int32_t CloseServerEvent(grpc_labview::gRPCid** id)
         return -1;
     }
     data->NotifyComplete();
-    data->_call->Finish();    
+    data->_call->Finish();
     return 0;
 }
 

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -231,7 +231,8 @@ namespace grpc_labview
         _shutdown = true;
         if (_server != nullptr)
         {
-            _server->Shutdown();
+            // We need shutdown passing a deadline so that any RPC calls in progress are terminated as well.
+            _server->Shutdown(std::chrono::system_clock::now());
             _server->Wait();
             _runThread->join();
             _server = nullptr;

--- a/src/lv_interop.cc
+++ b/src/lv_interop.cc
@@ -9,17 +9,22 @@
 #include <dlfcn.h>
 #endif
 
+static int kCleanOnRemove = 0;
+static int kCleanOnIdle = 2;
+
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 typedef int (*NumericArrayResize_T)(int32_t, int32_t, void* handle, size_t size);
 typedef int (*PostLVUserEvent_T)(grpc_labview::LVUserEventRef ref, void *data);
 typedef int (*Occur_T)(grpc_labview::MagicCookie occurrence);
+typedef int32_t(*RTSetCleanupProc_T)(grpc_labview::CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data, int32_t mode);
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 static NumericArrayResize_T NumericArrayResizeImp = nullptr;
 static PostLVUserEvent_T PostLVUserEvent = nullptr;
 static Occur_T Occur = nullptr;
+static RTSetCleanupProc_T RTSetCleanupProc = nullptr;
 
 namespace grpc_labview
 {
@@ -47,6 +52,7 @@ namespace grpc_labview
         NumericArrayResizeImp = (NumericArrayResize_T)GetProcAddress(lvModule, "NumericArrayResize");
         PostLVUserEvent = (PostLVUserEvent_T)GetProcAddress(lvModule, "PostLVUserEvent");
         Occur = (Occur_T)GetProcAddress(lvModule, "Occur");
+        RTSetCleanupProc = (RTSetCleanupProc_T)GetProcAddress(lvModule, "RTSetCleanupProc");
     }
 
 #else
@@ -74,6 +80,7 @@ namespace grpc_labview
             NumericArrayResizeImp = (NumericArrayResize_T)dlsym(lvModule, "NumericArrayResize");
             PostLVUserEvent = (PostLVUserEvent_T)dlsym(lvModule, "PostLVUserEvent");
             Occur = (Occur_T)dlsym(lvModule, "Occur");
+            RTSetCleanupProc = (RTSetCleanupProc_T)dlsym(lvModule, "RTSetCleanupProc");
         }
     }
 
@@ -124,5 +131,19 @@ namespace grpc_labview
 
         std::string result(chars, count);
         return result;
+    }
+
+    //---------------------------------------------------------------------
+    //---------------------------------------------------------------------
+    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* data)
+    {
+        return RTSetCleanupProc(cleanUpProc, data, kCleanOnIdle);
+    }
+
+    //---------------------------------------------------------------------
+    //---------------------------------------------------------------------
+    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* data)
+    {
+        return RTSetCleanupProc(cleanUpProc, data, kCleanOnRemove);
     }
 }

--- a/src/lv_interop.cc
+++ b/src/lv_interop.cc
@@ -9,7 +9,10 @@
 #include <dlfcn.h>
 #endif
 
+// Value passed to the RTSetCleanupProc to remove the clean up proc for the VI.
 static int kCleanOnRemove = 0;
+// Value passed to the RTSetCleanUpProc to register a cleanup proc for a VI which
+// gets called when the VI state changes to Idle.
 static int kCleanOnIdle = 2;
 
 //---------------------------------------------------------------------
@@ -17,7 +20,7 @@ static int kCleanOnIdle = 2;
 typedef int (*NumericArrayResize_T)(int32_t, int32_t, void* handle, size_t size);
 typedef int (*PostLVUserEvent_T)(grpc_labview::LVUserEventRef ref, void *data);
 typedef int (*Occur_T)(grpc_labview::MagicCookie occurrence);
-typedef int32_t(*RTSetCleanupProc_T)(grpc_labview::CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data, int32_t mode);
+typedef int32_t(*RTSetCleanupProc_T)(grpc_labview::CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* id, int32_t mode);
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
@@ -135,15 +138,15 @@ namespace grpc_labview
 
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
-    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* data)
+    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* id)
     {
-        return RTSetCleanupProc(cleanUpProc, data, kCleanOnIdle);
+        return RTSetCleanupProc(cleanUpProc, id, kCleanOnIdle);
     }
 
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
-    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* data)
+    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, gRPCid* id)
     {
-        return RTSetCleanupProc(cleanUpProc, data, kCleanOnRemove);
+        return RTSetCleanupProc(cleanUpProc, id, kCleanOnRemove);
     }
 }

--- a/src/lv_interop.h
+++ b/src/lv_interop.h
@@ -52,6 +52,7 @@ namespace grpc_labview
     typedef int32_t MagicCookie;
     typedef MagicCookie LVRefNum;
     typedef MagicCookie LVUserEventRef;
+    typedef int32_t(*CleanupProcPtr)(gRPCid* data);
 
     struct LStr {
         int32_t cnt; /* number of bytes that follow */
@@ -119,4 +120,6 @@ namespace grpc_labview
     int NumericArrayResize(int32_t typeCode, int32_t numDims, void* handle, size_t size);
     int PostUserEvent(LVUserEventRef ref, void *data);
     int SignalOccurrence(MagicCookie occurrence);
+    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data);
+    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data);
 }

--- a/src/lv_interop.h
+++ b/src/lv_interop.h
@@ -52,7 +52,7 @@ namespace grpc_labview
     typedef int32_t MagicCookie;
     typedef MagicCookie LVRefNum;
     typedef MagicCookie LVUserEventRef;
-    typedef int32_t(*CleanupProcPtr)(gRPCid* data);
+    typedef int32_t(*CleanupProcPtr)(gRPCid* id);
 
     struct LStr {
         int32_t cnt; /* number of bytes that follow */
@@ -120,6 +120,6 @@ namespace grpc_labview
     int NumericArrayResize(int32_t typeCode, int32_t numDims, void* handle, size_t size);
     int PostUserEvent(LVUserEventRef ref, void *data);
     int SignalOccurrence(MagicCookie occurrence);
-    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data);
-    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* data);
+    int32_t RegisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* id);
+    int32_t DeregisterCleanupProc(CleanupProcPtr cleanUpProc, grpc_labview::gRPCid* id);
 }


### PR DESCRIPTION
Changes made in this PR are:

- Added a new LV callback for RTSetCleanupProc. This would be used to setup cleanup procs which run when a VI goes to Idle.
- Changes in the grpc_client to register a cleanup proc when we create a grpc client and de-register it when we delete the client object.
- Now the grpc_client also keeps track of all the client calls that are active. This was needed since we need to cancel all these before we close the client connection.
- Changes in the grpc_server to register cleanup proc when we create the grpc server object. Now we pass a deadline of system_clock::now() to the server shutdown call so that we also shutdown any ongoing RPC calls immediately.