### PR TITLE
Fix byte alignment issues with 64 bit grpc-labview

### DIFF
--- a/src/cluster_copier.cc
+++ b/src/cluster_copier.cc
@@ -223,7 +223,7 @@ namespace grpc_labview {
                 int x = 0;
                 for (auto str : repeatedNested->_value)
                 {
-                    auto lvCluster = (*array)->bytes<LVCluster*>(x * clusterSize);
+                    auto lvCluster = (LVCluster**)(*array)->bytes(x * clusterSize, nestedMetadata->alignmentRequirement);
                     *lvCluster = nullptr;
                     CopyToCluster(*str, (int8_t*)lvCluster);
                     x += 1;
@@ -667,7 +667,7 @@ namespace grpc_labview {
 
                     for (int x = 0; x < count; ++x)
                     {
-                        auto data = (*array)->bytes<LVCluster*>(nestedMetadata->clusterSize * x);
+                        auto data = (LVCluster**)(*array)->bytes(nestedMetadata->clusterSize * x, nestedMetadata->alignmentRequirement);
                         auto nested = std::make_shared<LVMessage>(nestedMetadata);
                         repeatedValue->_value.push_back(nested);
                         CopyFromCluster(*nested, (int8_t*)data);

--- a/src/cluster_copier.cc
+++ b/src/cluster_copier.cc
@@ -667,7 +667,7 @@ namespace grpc_labview {
 
                     for (int x = 0; x < count; ++x)
                     {
-                        auto data = (LVCluster**)(*array)->bytes(nestedMetadata->clusterSize * x, nestedMetadata->alignmentRequirement);
+                        auto data = (LVCluster*)(*array)->bytes(nestedMetadata->clusterSize * x, nestedMetadata->alignmentRequirement);
                         auto nested = std::make_shared<LVMessage>(nestedMetadata);
                         repeatedValue->_value.push_back(nested);
                         CopyFromCluster(*nested, (int8_t*)data);

--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -47,7 +47,8 @@ namespace grpc_labview
         int clusterOffset = 0;
         if (lvMetadata->elements != nullptr)
         {
-            auto lvElement = (*lvMetadata->elements)->bytes<LVMesageElementMetadata>();
+            // byteAlignment for LVMesageElementMetadata would be the size of its largest element which is a LStrHandle
+            auto lvElement = (LVMesageElementMetadata*)(*lvMetadata->elements)->bytes(0, sizeof(LStrHandle));
             for (int x = 0; x < (*lvMetadata->elements)->cnt; ++x, ++lvElement)
             {
                 auto element = std::make_shared<MessageElementMetadata>(metadataOwner);
@@ -75,7 +76,8 @@ namespace grpc_labview
         int clusterOffset = 0;
         if (lvMetadata->elements != nullptr)
         {
-            auto lvElement = (*lvMetadata->elements)->bytes<LVMesageElementMetadata>();
+            // byteAlignment for LVMesageElementMetadata would be the size of its largest element which is a LStrHandle
+            auto lvElement = (LVMesageElementMetadata*)(*lvMetadata->elements)->bytes(0, sizeof(LStrHandle));
             for (int x = 0; x < (*lvMetadata->elements)->cnt; ++x, ++lvElement)
             {
                 auto element = std::make_shared<MessageElementMetadata>(metadataOwner);

--- a/src/lv_interop.cc
+++ b/src/lv_interop.cc
@@ -146,4 +146,18 @@ namespace grpc_labview
     {
         return RTSetCleanupProc(cleanUpProc, id, kCleanOnRemove);
     }
+
+    int AlignClusterOffset(int clusterOffset, int alignmentRequirement)
+    {
+#ifndef _PS_4
+        int remainder = abs(clusterOffset) % alignmentRequirement;
+        if (remainder == 0)
+        {
+            return clusterOffset;
+        }
+        return clusterOffset + alignmentRequirement - remainder;
+#else
+        return clusterOffset;
+#endif
+    }
 }

--- a/src/lv_interop.h
+++ b/src/lv_interop.h
@@ -46,6 +46,8 @@ namespace grpc_labview
         virtual ~gRPCid() { }
     };
 
+    int AlignClusterOffset(int clusterOffset, int alignmentRequirement);
+
     //---------------------------------------------------------------------
     // LabVIEW definitions
     //---------------------------------------------------------------------
@@ -69,43 +71,20 @@ namespace grpc_labview
         template<typename T>
         T* bytes()
         {
-    #ifndef _PS_4
-            if (sizeof(T) < 8)
-            {
-                return (T*)rawBytes;
-            }
-            return (T*)(rawBytes + 4); // 8-byte aligned data
-    #else
-            return (T*)rawBytes;
-    #endif
+            static_assert(!std::is_class<T>::value, "T must not be a struct/class type.");
+            return (T*)(bytes(0, sizeof(T)));
         }
 
         template<typename T>
         T* bytes(int byteOffset)
         {
-    #ifndef _PS_4
-            if (sizeof(T) < 8)
-            {
-                return (T*)(rawBytes + byteOffset);
-            }
-            return (T*)(rawBytes + 4 + byteOffset); // 8-byte aligned data
-    #else
-            return (T*)(rawBytes + byteOffset);
-    #endif
+            static_assert(!std::is_class<T>::value, "T must not be a struct/class type.");
+            return (T*)(bytes(byteOffset, sizeof(T)));
         }
 
         void* bytes(int byteOffset, int byteAlignment)
         {
-#ifndef _PS_4
-            int reminder = 4 % byteAlignment;
-            if (reminder == 0)
-            {
-                return (void*)(rawBytes + byteOffset);
-            }
-            return (void*)(rawBytes + byteAlignment - reminder + byteOffset); // 8-byte aligned data
-#else
-            return (void*)(rawBytes + byteOffset);
-#endif
+            return (void*)(rawBytes + AlignClusterOffset(4, byteAlignment) - 4 + byteOffset);
         }
     };
 

--- a/src/lv_interop.h
+++ b/src/lv_interop.h
@@ -93,6 +93,20 @@ namespace grpc_labview
             return (T*)(rawBytes + byteOffset);
     #endif
         }
+
+        void* bytes(int byteOffset, int byteAlignment)
+        {
+#ifndef _PS_4
+            int reminder = 4 % byteAlignment;
+            if (reminder == 0)
+            {
+                return (void*)(rawBytes + byteOffset);
+            }
+            return (void*)(rawBytes + byteAlignment - reminder + byteOffset); // 8-byte aligned data
+#else
+            return (void*)(rawBytes + byteOffset);
+#endif
+        }
     };
 
     using LV1DArrayPtr = LV1DArray*;

--- a/src/message_element_metadata_owner.cc
+++ b/src/message_element_metadata_owner.cc
@@ -136,9 +136,7 @@ namespace grpc_labview {
                 int elementSize = 0;
                 if (element->isRepeated)
                 {
-                    elementSize = ClusterElementSize(element->type, element->isRepeated);
-                    // This should be the alignmentRequirement of the LV1DArray struct which should be 4 (contains int32 and int8)
-                    alignmentRequirement = 4;
+                    alignmentRequirement = elementSize = ClusterElementSize(element->type, element->isRepeated);
                 }
                 else
                 {
@@ -157,21 +155,11 @@ namespace grpc_labview {
             {
                 clusterOffset = AlignClusterOffset(clusterOffset, element->type, element->isRepeated);
                 element->clusterOffset = clusterOffset;
-                int alignmentRequirement = 0;
-                auto elementSize = ClusterElementSize(element->type, element->isRepeated);
+                int elementSize = ClusterElementSize(element->type, element->isRepeated);
                 clusterOffset += elementSize;
-                if (element->isRepeated)
+                if (maxAlignmentRequirement < elementSize)
                 {
-                    // This should be the alignmentRequirement of the LV1DArray struct which should be 4 (contains int32 and int8)
-                    alignmentRequirement = 4;
-                }
-                else
-                {
-                    alignmentRequirement = elementSize;
-                }
-                if (maxAlignmentRequirement < alignmentRequirement)
-                {
-                    maxAlignmentRequirement = alignmentRequirement;
+                    maxAlignmentRequirement = elementSize;
                 }
             }
         }

--- a/src/message_element_metadata_owner.cc
+++ b/src/message_element_metadata_owner.cc
@@ -20,32 +20,9 @@ namespace grpc_labview {
     //---------------------------------------------------------------------
     int ClusterElementSize(LVMessageMetadataType type, bool repeated)
     {
-    #ifndef _PS_4
         if (repeated)
         {
-            return 8;
-        }
-        switch (type)
-        {
-        case LVMessageMetadataType::BoolValue:
-            return 1;
-        case LVMessageMetadataType::EnumValue:
-        case LVMessageMetadataType::Int32Value:
-        case LVMessageMetadataType::UInt32Value:
-        case LVMessageMetadataType::FloatValue:
-            return 4;
-        case LVMessageMetadataType::Int64Value:
-        case LVMessageMetadataType::UInt64Value:
-        case LVMessageMetadataType::DoubleValue:
-        case LVMessageMetadataType::StringValue:
-        case LVMessageMetadataType::BytesValue:
-        case LVMessageMetadataType::MessageValue:
-            return 8;
-        }
-    #else
-        if (repeated)
-        {
-            return 4;
+            return sizeof(void*);
         }
         switch (type)
         {
@@ -56,43 +33,28 @@ namespace grpc_labview {
         case LVMessageMetadataType::EnumValue:
         case LVMessageMetadataType::FloatValue:
             return 4;
-        case LVMessageMetadataType::StringValue:
-        case LVMessageMetadataType::BytesValue:
-        case LVMessageMetadataType::MessageValue:
-            return 4;
         case LVMessageMetadataType::Int64Value:
         case LVMessageMetadataType::UInt64Value:
         case LVMessageMetadataType::DoubleValue:
             return 8;
+        case LVMessageMetadataType::StringValue:
+        case LVMessageMetadataType::BytesValue:
+        case LVMessageMetadataType::MessageValue:
+            return sizeof(void*);
         }
-    #endif
         return 0;
-    }
-
-    int AlignClusterOffset(int clusterOffset, int alignmentRequirement)
-    {
-        int remainder = abs(clusterOffset) % alignmentRequirement;
-        if (remainder == 0)
-        {
-            return clusterOffset;
-        }
-        return clusterOffset + alignmentRequirement - remainder;
     }
 
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
     int AlignClusterOffset(int clusterOffset, LVMessageMetadataType type, bool repeated)
     {
-    #ifndef _PS_4
         if (clusterOffset == 0)
         {
             return 0;
         }
         auto multiple = ClusterElementSize(type, repeated);
         return AlignClusterOffset(clusterOffset, multiple);
-    #else
-        return clusterOffset;
-    #endif
     }
 
     //---------------------------------------------------------------------

--- a/src/message_metadata.h
+++ b/src/message_metadata.h
@@ -93,6 +93,7 @@ namespace grpc_labview
         std::string messageName;
         std::string typeUrl;
         int clusterSize;
+        int alignmentRequirement;
         LVMessageMetadataList _elements;
         LVMessageMetadataMap _mappedElements;
     };


### PR DESCRIPTION
Fix for Issue #119 

- Updating calculation of cluster byte alignment for 64 bit grpc-labview to be based on the biggest byte alignment requirement we have seen among all the elements of the cluster. This is a recursive calculation in the case of nested clusters.

Tested the fix with the following configurations for the payload we are packing/unpacking.
- Nested clusters (#119)
- Clusters with strings
- Clusters with arrays
- Clusters with arrays of clusters
- Clusters with arrays of strings