### PR TITLE
Delete the CallFinishedData object once done

### DIFF
--- a/src/event_data.cc
+++ b/src/event_data.cc
@@ -43,7 +43,8 @@ namespace grpc_labview
     //---------------------------------------------------------------------
     void CallFinishedData::Proceed(bool ok)
     {
-        _call->CallFinished();    
+        _call->CallFinished();
+        delete this;
     }
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
Fix for memory leak reported in #124

Profiling while running the example attached to #124 revealed that the issue was the `CallFinishedData` object which is created for every call [here](https://github.com/ni/grpc-labview/blob/83f85d1fad2fab22ce342a8cdabb4773c79e86d0/src/event_data.cc#L166) and is never deleted. I have made a change to delete the `CallFinishedData` after `Proceed()` is called on it. This fixed the memory leak we were seeing with the example.