### PR TITLE
Fix crash in UpdateMetadataClusterLayout with empty messages

### DIFF
--- a/src/message_element_metadata_owner.cc
+++ b/src/message_element_metadata_owner.cc
@@ -82,10 +82,10 @@ namespace grpc_labview {
     //---------------------------------------------------------------------
     void MessageElementMetadataOwner::UpdateMetadataClusterLayout(std::shared_ptr<MessageMetadata>& metadata)
     {
-        if (metadata->clusterSize != 0)
+        if (metadata->clusterSize != 0 || metadata->_elements.size() == 0)
         {
             return;
-        }    
+        }
         int clusterOffset = 0;
         int maxAlignmentRequirement = 0;
         for (auto element: metadata->_elements)


### PR DESCRIPTION
When the gRPC message is empty there was buggy code in UpdateMetadataClusterLayout [here](https://github.com/ni/grpc-labview/blob/1e3b85cb7b4e3de968d30b7f507a80f5b09780fe/src/message_element_metadata_owner.cc#L129) which would try to   align offsets using 0 as the alignment requirement which leads to a crash. This PR fixes this issue.