### PR TITLE
Fix crash while unloading labview-grpc dll

### DIFF
--- a/src/event_data.cc
+++ b/src/event_data.cc
@@ -192,7 +192,7 @@ namespace grpc_labview
                 _requestDataReady = true;
 
                 _methodData = std::make_shared<GenericMethodData>(this, &_ctx, _request, _response);
-                gPointerManager.RegisterPointer(_methodData.get());
+                gPointerManager.RegisterPointer(_methodData);
                 _server->SendEvent(name, static_cast<gRPCid*>(_methodData.get()));
             }
             else

--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -269,6 +269,7 @@ LIBRARY_EXPORT int32_t CloseServerEvent(grpc_labview::gRPCid** id)
     }
     data->NotifyComplete();
     data->_call->Finish();
+    grpc_labview::gPointerManager.UnregisterPointer(*id);
     return 0;
 }
 


### PR DESCRIPTION
Fix for Issue #140 

With the test case in the issue above, we would have created a shared pointer to `GenericMethodData` [here](https://github.com/ni/grpc-labview/blob/ff2aad23e6c02f2a462d22faa1acef1e5358a8b2/src/event_data.cc#L194) and do a get on the shared_ptr to pass it to the token manager to be registered. This would mean we now have two separate shared_ptr's for the `GenericMethodData` object.

When the `CallData` object which owns the `_methodData` shared_ptr is destroyed, it would delete the underlying object but the shared_ptr to it in the token manager would still be around. On dll unload, we will try to destroy token manager instance which in turn will call the destructors on the map token manager holds and eventually the `GenericMethodData` object. Since this object would already be destroyed we would crash here.

Made a change to the token manager to add an overload to `RegisterPointer` which takes in a shared_ptr instead of the raw pointer.