### PR TITLE
Use sync object to protect call list within client

### DIFF
--- a/src/grpc_client.h
+++ b/src/grpc_client.h
@@ -30,6 +30,7 @@ namespace grpc_labview
     public:
         std::shared_ptr<grpc::Channel> Channel;
         std::list<ClientCall*> ActiveClientCalls;
+        std::mutex clientLock;
     };
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
This is a simplistic fix for the bug #161  we are seeing where we crash when sending multiple gRPC commands at one time. The issue appeared to be missing synchronization protecting the std::list containing the active calls on a client.

Note: A cleaner fix would be to encapsulate adding/removing to the list as a method that internally grabs the sync object.