### PR TITLE
Fix Linux debug build documentation

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -90,7 +90,7 @@ Build Debug
 ```
 > mkdir -p cmake/build
 > cd cmake/build
-> cmake ../..
+> cmake -DCMAKE_BUILD_TYPE=Debug ../..
 > make
 ```
 
@@ -129,7 +129,7 @@ Build Debug
 ```
 > mkdir -p cmake/build
 > cd cmake/build
-> cmake ../..
+> cmake -DCMAKE_BUILD_TYPE=Debug ../..
 > make
 ```
 


### PR DESCRIPTION
For the default Makefile generator using on Linux, CMake does not default to "Debug". You do not get full debug symbols built into the linked binaries as a result. This changes the documentation to tell you to explicitly pass the Debug build type.