### PR TITLE
Add setup-python github action

### DIFF
--- a/.github/workflows/build_release_artifacts.yml
+++ b/.github/workflows/build_release_artifacts.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - uses: actions/download-artifact@v3
       id: download_artifacts
       with:


### PR DESCRIPTION
The build_release_artifacts relied on python being installed on the self-hosted runner which started failing in [this](https://github.com/ni/grpc-labview/actions/runs/3207102531/jobs/5261731504) run complaining that python wasn't found. Added a setup-python action to the script to ensure we have the required python version on the machine.