### PR TITLE
Fix for crash when server doesn't implement client method

### DIFF
--- a/src/event_data.cc
+++ b/src/event_data.cc
@@ -204,8 +204,9 @@ namespace grpc_labview
             }
             else
             {
+                _status = CallStatus::Finish;
                 _stream.Finish(grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""), this);
-            }       
+            }
         }
         else if (_status == CallStatus::Writing)
         {

--- a/src/event_data.cc
+++ b/src/event_data.cc
@@ -172,8 +172,17 @@ namespace grpc_labview
             // part of its FINISH state.
             new CallData(_server, _service, _cq);
 
-            _stream.Read(&_rb, this);
-            _status = CallStatus::Process;
+            auto name = _ctx.method();
+            if (_server->HasRegisteredServerMethod(name) || _server->HasGenericMethodEvent())
+            {
+                _stream.Read(&_rb, this);
+                _status = CallStatus::Process;
+            }
+            else
+            {
+                _status = CallStatus::Finish;
+                _stream.Finish(grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""), this);
+            }
         }
         else if (_status == CallStatus::Process)
         {
@@ -195,7 +204,7 @@ namespace grpc_labview
             }
             else
             {
-                _stream.Finish(grpc::Status::CANCELLED, this);
+                _stream.Finish(grpc::Status(grpc::StatusCode::UNIMPLEMENTED, ""), this);
             }       
         }
         else if (_status == CallStatus::Writing)

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -74,6 +74,11 @@ namespace grpc_labview
         return false;
     }
 
+    bool LabVIEWgRPCServer::HasRegisteredServerMethod(std::string methodName)
+    {
+        return _registeredServerMethods.find(methodName) != _registeredServerMethods.end();
+    }
+
     //---------------------------------------------------------------------
     //---------------------------------------------------------------------
     bool LabVIEWgRPCServer::HasGenericMethodEvent()

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -94,12 +94,13 @@ namespace grpc_labview
         void SendEvent(std::string name, gRPCid* data);
 
         bool FindEventData(std::string name, LVEventData& data);
-        bool HasGenericMethodEvent();    
+        bool HasGenericMethodEvent();
+        bool HasRegisteredServerMethod(std::string methodName);
 
     private:
         std::mutex _mutex;
         std::unique_ptr<Server> _server;
-        std::map<std::string, LVEventData> _registeredServerMethods;    
+        std::map<std::string, LVEventData> _registeredServerMethods;
         LVUserEventRef _genericMethodEvent;
         std::unique_ptr<grpc::AsyncGenericService> _rpcService;
         std::unique_ptr<std::thread> _runThread;


### PR DESCRIPTION
Fix for Issue #176 

**Issue**
With the issue described in the bug LabVIEW would crash if the gRPC server doesn't implement the method that the client is calling. Debugging the issue I found that the crash happened [here](https://github.com/ni/grpc-labview/blob/b94680b19034b4e6edae7f9746bd967f37c1c329/src/event_data.cc#L198) with an error saying there were too many operations in progress. This seemed to be because we had already done a Read on the stream and we expected a write before we called Finish() on the stream.

**Fix**
Moving the check to the Read case above fixed the issue so that if we run across a method that isn't implemented we call finish on the stream and set the error code without ever trying to use the stream.

**Testing**
Tested the fix against different types of calls (Unary and different streaming types).