### PR TITLE
fix the build scripts to handle library version

### DIFF
--- a/build-it/build.py
+++ b/build-it/build.py
@@ -98,7 +98,7 @@ def main():
     if args.libraryVersion != "" :
         vipb_files = vipb_helper.get_vipb_files(gRPCPackageBuilder.root_directory)
         for vipb_file in vipb_files:
-            vipb_helper.update_vipb_verion(vipb_file = vipb_file, library_version = args.libraryVersion)
+            vipb_helper.update_vipb_version(vipb_file = vipb_file, library_version = args.libraryVersion)
 
     if args.target != "Win32" and args.target != "Win64" and args.target != "All":
             raise Exception("Build target should be one off Win32, Win64 or All. Passed build target is " + args.target)

--- a/build-it/update_vipb_version.py
+++ b/build-it/update_vipb_version.py
@@ -8,7 +8,7 @@ def main():
     root_directory = os.path.dirname(build_script_directory)
     vipb_files =  vipb_helper.get_vipb_files(root_directory=root_directory)
     for vipb_file in vipb_files:
-        vipb_helper.update_vipb_verion(vipb_file=vipb_file, library_version=args.library_version)
+        vipb_helper.update_vipb_version(vipb_file=vipb_file, library_version=args.library_version)
 
 def parse_args():
     parser = argparse.ArgumentParser(

--- a/build-it/vipb_helper.py
+++ b/build-it/vipb_helper.py
@@ -2,9 +2,10 @@ import glob
 import os
 import subprocess
 
-def update_vipb_verion(vipb_file, library_version):
+def update_vipb_version(vipb_file, library_version):
     build_script_directory = os.path.abspath(os.path.dirname(__file__))
     build_vi_path = os.path.join(build_script_directory, "LV Build", "UpgradeVIPBVersion.vi")
+    library_version = format_version(library_version)
     update_vipb_version = subprocess.run(["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", build_vi_path, vipb_file, library_version], capture_output = True)
     if(update_vipb_version.returncode != 0):
         raise Exception(update_vipb_version.stderr.decode())
@@ -13,3 +14,10 @@ def get_vipb_files(root_directory):
     labview_source_directory = os.path.join(root_directory, "labview source")
     vipb_paths = glob.glob(labview_source_directory + '**/**/*.vipb', recursive=True)
     return vipb_paths
+
+# TODO: find a better way to handle this formatting
+def format_version(input_version):
+    if input_version !="" and input_version[0]=="v" :
+        input_version = input_version[1:]
+    return input_version
+    


### PR DESCRIPTION
The build scripts do not handle the --libraryVersion argument properly, for example when we do git push origin v1.0.0.1, the library version it was trying to create was 0.0.0.1 which is wrong. For now I have added a method to just handle this kind of case(prase v1.0.0.1 into 1.0.0.1) but we need to handle version parsing in a better way