### PR TITLE
fix vipb depdency for 1.0.0.2

### DIFF
--- a/labview source/Client Server Support New/build spec/gRPC Server and Client Template [2].vipb
+++ b/labview source/Client Server Support New/build spec/gRPC Server and Client Template [2].vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-10-29 00:29:27" Modified_Date="2023-04-27 06:00:45" Creator="navin" Comments="" ID="e18e1be35c57058b9bc69efe4291503d">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-10-29 00:29:27" Modified_Date="2023-05-03 17:41:01" Creator="navin" Comments="" ID="813b285e62cfba1f7367833a43104dab">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_gRPC_Server_and_Client_Template[2]</Package_File_Name>
     <Library_Version>1.0.0.2</Library_Version>
@@ -17,8 +17,8 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.1</Additional_External_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_servicer &gt;=1.0.0.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.2</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_servicer &gt;=1.0.0.2</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI/>

--- a/labview source/gRPC lv Servicer/build spec/LabVIEW gRPC Servicer.vipb
+++ b/labview source/gRPC lv Servicer/build spec/LabVIEW gRPC Servicer.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-19 18:41:05" Modified_Date="2023-04-27 06:00:51" Creator="navin" Comments="" ID="ac16a5b91741c33fa146b600846a1ff5">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-19 18:41:05" Modified_Date="2023-05-03 17:40:28" Creator="navin" Comments="" ID="660bdf3db475b546841ae51886dccf72">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_LabVIEW_gRPC_Servicer</Package_File_Name>
     <Library_Version>1.0.0.2</Library_Version>
@@ -17,7 +17,7 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.2</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI/>
@@ -241,7 +241,7 @@
         <Path>..\Servicer</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>F8C87FC5B6A37D1EFC36F04105394AD7</GUID>
+      <GUID>8B6B36696D9F3C759F22BEA76B573074</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>0</Parent_Palette_Index>
@@ -290,7 +290,7 @@
         <Path>..\iService\Server API</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>5ADB509A8487C9CC9FAB3E868C0327D4</GUID>
+      <GUID>267BAD051989BB4D58EF2669B95ECBAC</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>0</Parent_Palette_Index>
@@ -353,7 +353,7 @@
         <Path>..\Servicer\Run Servicer.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>405415C41501F8DF54DC26E22C55B6D5</GUID>
+      <GUID>9FE313C4A0876609729577E8CC883CF1</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>1</Parent_Palette_Index>
@@ -402,7 +402,7 @@
         <Path>..\ServiceBase\Accessors\Read Server Stop.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>FA39D316701927042943ECC790A496F8</GUID>
+      <GUID>DBCF77D46CFB2CE0AAB88E374F97ECAC</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>1</Parent_Palette_Index>
@@ -507,7 +507,7 @@
         <Path>..\ServiceBase\Server API\Start.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>7FDFC9CDD377A26475E3E4A72367550B</GUID>
+      <GUID>434DA9043CEC8776625F14700A350990</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>2</Parent_Palette_Index>
@@ -598,7 +598,7 @@
         <Path>..\Servicer\Accessors\Server State</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>BA8765C45FE659CD0A46AF8226793998</GUID>
+      <GUID>35FCDE0B378A6855A8F26FDD3DEB3AFB</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>2</Parent_Palette_Index>
@@ -675,7 +675,7 @@
         <Path>..\Servicer\Server API\Stop Server.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>CB82202676054581AF80C3C879582DA6</GUID>
+      <GUID>D6429874DE26F373979AF2B92F6AB220</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>5</Parent_Palette_Index>
@@ -724,7 +724,7 @@
         <Path>..\Servicer\Accessors\gRPC ID\Set gRPC ID.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>C1BD04506D71A9E8D971EC73BC55447D</GUID>
+      <GUID>00A94A9231D8E88B733713CE014C560C</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>5</Parent_Palette_Index>
@@ -773,7 +773,7 @@
         <Path>..\Servicer\Accessors\Server Address\Set Server Address.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>48374C4259DE23936FB3A445A56C82EF</GUID>
+      <GUID>55F6233B11725E3CDE1C51460D01DC80</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>5</Parent_Palette_Index>
@@ -822,7 +822,7 @@
         <Path>..\Servicer\Accessors\Server Certificate File\Set Server Certificate File.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>FC4697E8E0A90EF007839B89DB5E6E71</GUID>
+      <GUID>4CF2F18F9FD3FBE65B9BE79E450D5C58</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>5</Parent_Palette_Index>
@@ -871,7 +871,7 @@
         <Path>..\Servicer\Accessors\Server Key File\Set Server Key File.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>FEBD1F52CBF569DBAC85DCA8245E7547</GUID>
+      <GUID>48570A761DB330092C78256009E3C3C6</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>5</Parent_Palette_Index>
@@ -948,7 +948,7 @@
         <Path>..\Servicer\Accessors\Server State\Set Server State.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>FEA285A957364CF1DDFE6129D575CF6D</GUID>
+      <GUID>FEEF26FB9E181746CB73DD2ED2FD5A17</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>11</Parent_Palette_Index>
@@ -997,7 +997,7 @@
         <Path>..\Servicer\Accessors\Server State\State Ref\Set Server State Ref.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>5FF65C5116B7C322ED128392754C4140</GUID>
+      <GUID>5D8EABD6A94E77C61ACA272D49E63298</GUID>
     </Functions_Palette_Data>
     <Functions_Palette_Data>
       <Parent_Palette_Index>11</Parent_Palette_Index>
@@ -1046,7 +1046,7 @@
         <Path>..\Servicer\Accessors\Server State\State UE\Set Server State UE.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>7B5D50FA31D2DE89E8A77462F523ECE6</GUID>
+      <GUID>98FE6DFECF3C44BB85F15CD681911BD6</GUID>
     </Functions_Palette_Data>
   </Library_Palette_Definition>
 </VI_Package_Builder_Settings>


### PR DESCRIPTION
The depdendency on library vipb for template vipb and servicer vipb  is pointing to >=1.0.0.1 which is incorrect, it should be >=1.0.0.2