### PR TITLE
fix NumericArrayResize to allocate correctly for UInt64Arrays in CopyUInt64ToCluster

### DIFF
--- a/src/cluster_copier.cc
+++ b/src/cluster_copier.cc
@@ -400,7 +400,7 @@ namespace grpc_labview {
             auto repeatedUInt64 = std::static_pointer_cast<LVRepeatedUInt64MessageValue>(value);
             if (repeatedUInt64->_value.size() != 0)
             {
-                NumericArrayResize(0x03, 1, start, repeatedUInt64->_value.size());
+                NumericArrayResize(0x08, 1, start, repeatedUInt64->_value.size());
                 auto array = *(LV1DArrayHandle*)start;
                 (*array)->cnt = repeatedUInt64->_value.size();
                 auto byteCount = repeatedUInt64->_value.size() * sizeof(uint64_t);


### PR DESCRIPTION
fix for #230 

We are allocating arrays for int32 type in [`CopyUInt64ToCluster`()](https://github.com/ni/grpc-labview/blob/058070d706c85d650ab001e31e6489e2ba07d643/src/cluster_copier.cc#L403), but writing uint64 integers to those [here](https://github.com/ni/grpc-labview/blob/058070d706c85d650ab001e31e6489e2ba07d643/src/cluster_copier.cc#L407). This writes past the allocated block and causes memory corruption and later results in crashes as mentioned in the issue.

fix is to pass correct `typecode=0x08`  to `NumericArrayResize()` so that it can allocate memory corresponding to uint64.
