### PR TITLE
fix enum parsing for imported proto

### DIFF
--- a/src/proto_parser.cc
+++ b/src/proto_parser.cc
@@ -308,15 +308,20 @@ LIBRARY_EXPORT int LVGetMessages(grpc_labview::LVProtoParser* parser, grpc_labvi
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
-void AddTopLevelEnums(grpc_labview::LVProtoParser* parser, std::set<const google::protobuf::EnumDescriptor*>& allEnums)
+void AddTopLevelEnums(const google::protobuf::FileDescriptor& descriptor, std::set<const google::protobuf::EnumDescriptor*>& allEnums)
 {
-    // Get global enums defined in the proto file.
+    // Get global enums defined in the proto file and other imported proto files.
     // FileDescriptor is being used to fetch these enum descriptors.
-    const FileDescriptor* descriptor = parser->m_FileDescriptor;
-    int topLevelEnumCount = descriptor->enum_type_count();
+    auto noOfImportedFiles = descriptor.dependency_count();
+    for (int x = 0; x < noOfImportedFiles; ++x)
+    {
+        AddTopLevelEnums(*descriptor.dependency(x), allEnums);
+    }
+
+    int topLevelEnumCount = descriptor.enum_type_count();
     for (int x = 0; x < topLevelEnumCount; ++x)
     {
-        auto current = descriptor->enum_type(x);
+        auto current = descriptor.enum_type(x);
         allEnums.emplace(current);
     }
 }
@@ -359,7 +364,7 @@ LIBRARY_EXPORT int LVGetEnums(grpc_labview::LVProtoParser* parser, grpc_labview:
     }
 
     std::set<const google::protobuf::EnumDescriptor*> allEnums;
-    AddTopLevelEnums(parser, allEnums);
+    AddTopLevelEnums(*(parser->m_FileDescriptor), allEnums);
     AddNestedEnums(messages, allEnums);    
 
     auto count = allEnums.size();


### PR DESCRIPTION
fix for https://github.com/ni/grpc-labview/issues/261
- added support for parsing enums from imported proto files
- tested locally by defining enums in a proto files and using them in other proto files.

**Note**:- Right now the parsing is in-efficient i.e. we are doing two rounds of recursive dependency proto descriptor parsing, one for regular messages and one for enums. We should make it more efficient i.e. in one shot we should get all information but it requires some extra changes.