### PR TITLE
Enable all-datatypes-oneof test

### DIFF
--- a/tests/New_ATS/pylib/testlist.json
+++ b/tests/New_ATS/pylib/testlist.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": ["enum-oneof", "helloworld", "message-oneof", "multiple-field-oneof", "nested-oneof", "sibling-oneof", "simple-oneof"],
+    "name": ["all-datatypes-oneof", "enum-oneof", "helloworld", "message-oneof", "multiple-field-oneof", "nested-oneof", "sibling-oneof", "simple-oneof"],
     "gen_type": "0",
     "labview_version": "2019",
     "labview_bitness": "32"


### PR DESCRIPTION
Enabling a test which verifies that the oneof feature supports all datatypes that can be used for the fields of a oneof.