### PR TITLE
put debug messages under debug #ifndef NDEBUG

### DIFF
--- a/src/pointer_manager.h
+++ b/src/pointer_manager.h
@@ -72,7 +72,9 @@ namespace grpc_labview
         auto storedPtr = _registeredPointers.find(ptr);
         if (storedPtr == _registeredPointers.end())
         {
+#ifndef  NDEBUG
             std::cerr << "ERROR: THIS POINTER IS NOT REGISTERED" << std::endl;
+#endif // ! NDEBUG
             if (status != nullptr)
             {
                 *status = -1;
@@ -83,7 +85,9 @@ namespace grpc_labview
         std::shared_ptr<TDerivedType> derivedPtr = std::dynamic_pointer_cast<TDerivedType>(storedPtr->second);
         if (!derivedPtr)
         {
+#ifndef  NDEBUG
             std::cerr << "ERROR: CASTING POINTER TO MORE SPECIFIC TYPE FAILED" << std::endl;
+#endif // ! NDEBUG
             if (status != nullptr)
             {
                 *status = -1;
@@ -100,7 +104,9 @@ namespace grpc_labview
         std::lock_guard<std::mutex> lock(_mutex);
         if (!ptr)
         {
+#ifndef  NDEBUG
             std::cerr << "ERROR: CANNOT REGISTER A NULL POINTER" << std::endl;
+#endif // ! NDEBUG
             return nullptr;
         }
 
@@ -117,7 +123,9 @@ namespace grpc_labview
         std::lock_guard<std::mutex> lock(_mutex);
         if (!ptr)
         {
+#ifndef  NDEBUG
             std::cerr << "ERROR: CANNOT REGISTER A NULL POINTER" << std::endl;
+#endif // ! NDEBUG
             return nullptr;
         }
 


### PR DESCRIPTION
A custom orchestration tool has a functionality to be called from CMD. With the new offering version the gRPC APIs are printing error every time when those are called in the code. This issue wasn't in the previous version of the gRPC llb.

This PR provides a fix for this issue. Note that this change has already been submitted to the master branch, but the customer needs it specifically for v1.0.0.5 since they are not able to upgrade to the latest release. So the commit has been based off the tag v1.0.0.5.
