### PR TITLE
Added support for function overloading in CMakeTests

### DIFF
--- a/tests/CMakeTests/tests/Utils/get_exported_function_list.py
+++ b/tests/CMakeTests/tests/Utils/get_exported_function_list.py
@@ -54,16 +54,21 @@ def getFunctionSignatureList():
     for i in range(len(sorted_signature_list["signatures"])):
         sorted_signature_list["signatures"][i]["id"] = i
         signature = sorted_signature_list["signatures"][i]
-        function_map[signature['function_name']] = {"function_name": signature["function_name"], "return_type": signature['return_type'], "parameter_list": signature['parameter_list']}
+        if function_map.get(signature['function_name']) == None:
+            function_map[signature['function_name']] = []
+        function_map[signature['function_name']].append({"function_name": signature["function_name"], "return_type": signature['return_type'], "parameter_list": signature['parameter_list']})
     
     return [sorted_signature_list, function_map]
 
 def getFunctionMap(sorted_signature_list):
     function_map = {}
     for signature in sorted_signature_list['signatures']:
-        function_map[signature['function_name']] = {"function_name": signature["function_name"], "return_type": signature['return_type'], "parameter_list": signature['parameter_list']}
+        if function_map.get(signature['function_name']) == None:
+            function_map[signature['function_name']] = []
+        function_map[signature['function_name']].append({"function_name": signature["function_name"], "return_type": signature['return_type'], "parameter_list": signature['parameter_list']})
     return function_map
 
 if __name__ == '__main__':
-    with open("exported_function_list.json",'w') as f:
+    exported_function_list_file_path = Path(__file__).parent / "exported_function_list.json"
+    with open(exported_function_list_file_path,'w') as f:
         json.dump(getFunctionSignatureList()[0],f, indent=2)

--- a/tests/CMakeTests/tests/exported_functions_addition_test.py
+++ b/tests/CMakeTests/tests/exported_functions_addition_test.py
@@ -16,9 +16,12 @@ old_function_map = get_exported_functions.getFunctionMap(old_function_list)
 if new_function_list["size"] != old_function_list["size"]:
     func_name = ""
     cnt = 1
-    for func in new_function_map.keys():
-        if old_function_map.get(func) == None:
-           func_name += str(cnt) + ") " + func + '\n'
-           cnt += 1
+    for function_name in new_function_map.keys():
+        new_function_list = new_function_map.get(function_name)
+        old_function_list = old_function_map.get(function_name)
+        for function_signature in new_function_list:
+            if (old_function_list == None) or (function_signature not in old_function_list):
+                func_name += str(cnt) + ") " + function_signature['function_name'] + '\n'
+                cnt += 1
 
     print(f"{func_name}")

--- a/tests/CMakeTests/tests/exported_functions_test.py
+++ b/tests/CMakeTests/tests/exported_functions_test.py
@@ -14,6 +14,12 @@ parsed_exported_function_list, parsed_function_map = get_exported_function_list.
 
 @pytest.mark.parametrize('function_signature', read_json(exported_functions_json_file_path)['signatures'])
 def test_function_compatibility(function_signature):
-    test_input = parsed_function_map.get(function_signature['function_name'])
+    test_input_list = parsed_function_map.get(function_signature['function_name'])
     expected_output = {"function_name": function_signature["function_name"], "return_type": function_signature["return_type"], "parameter_list": function_signature["parameter_list"]}
-    assert test_input == expected_output
+    if test_input_list == None:
+        assert None == expected_output
+    for test_input in test_input_list:
+        if test_input == expected_output:
+            assert test_input == expected_output
+            return
+    assert None == expected_output


### PR DESCRIPTION
Converted exported_function_map to point to a list rather than a single function signature so that we can support function overloading