### PR TITLE
Update sync_issues_to_azdo.yml to match AzDO area path update

### DIFF
--- a/.github/workflows/sync_github_issue_azdo.yml
+++ b/.github/workflows/sync_github_issue_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Test System SW\\Dev Tools\\LabVIEW\\NIB"
+          ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\Core SW and Drivers\\Test System SW\\Dev Tools\\LabVIEW\\NIB"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
The NIB area path in Azure DevOps has been moved, so reflect that change in where Bugs for GitHub Issues area created.