### PR TITLE
added a _cancelled flag for the client call to track if the call was cancelled

### DIFF
--- a/src/grpc_client.cc
+++ b/src/grpc_client.cc
@@ -60,6 +60,7 @@ namespace grpc_labview
     void ClientCall::Cancel()
     {
         _context.get()->Cancel();
+        _cancelled = true;
     }
 
     //---------------------------------------------------------------------
@@ -201,6 +202,10 @@ void CheckActiveAndSignalOccurenceForClientCall(grpc_labview::ClientCall *client
     if (clientCall == nullptr)
     {
         return;
+    }
+    if (clientCall->_cancelled == true)
+    {
+        grpc_labview::SignalOccurrence(clientCall->_occurrence);
     }
     std::unique_lock<std::mutex> lock(clientCall->_client->clientLock);
     if (clientCall->_client->ActiveClientCalls.find(clientCall) != clientCall->_client->ActiveClientCalls.end())

--- a/src/grpc_client.h
+++ b/src/grpc_client.h
@@ -62,6 +62,7 @@ namespace grpc_labview
         grpc::Status _status;
         std::future<int> _runFuture;
         bool _useLVEfficientMessage;
+        bool _cancelled = false;
     };
 
     //---------------------------------------------------------------------


### PR DESCRIPTION
fix for #345 #354 
When we have multiple streaming calls doing read operations in parallel and we cancel those calls, some of the calls will complete with correct error status(as they finished reading the stream and the subsequent reads are not valid) and some calls might hang as they are waiting on occurrence to get signaled from async c++ thread.

When we cancelled the calls, they get removed form ActiveCalls list. Once we complete any read in async C++ thread, we always signal the occurrence corresponding to calls present in this active call list only. But if the call was cancelled, it will get removed this list and we will end up not signaling for it and VI will hang in Wait for occurrence. 

To fix this added a `_cancelled` flag in `ClientCall` to keep track if the call was cancelled. If cancelled that async ++ thread will signal occurrence now. 

Note: I want to add one LV client server test for this but I have to add some infrastructure to do that in existing ATS.