### PR TITLE
Update to only export LIBRARY_EXPORT symbols from the shared library for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(labview-grpc C CXX)
 
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+  # Set default visibility to hidden, only export LIBRARY_EXPORT symbols from the shared library
+  add_compile_options(-fvisibility=hidden)
 else()
   add_definitions(-D_WIN32_WINNT=0x600)
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/src/lv_interop.h
+++ b/src/lv_interop.h
@@ -20,7 +20,7 @@
 #ifdef _WIN32
     #define LIBRARY_EXPORT extern "C" __declspec(dllexport)
 #else
-    #define LIBRARY_EXPORT extern "C"
+    #define LIBRARY_EXPORT extern "C" __attribute__((visibility("default")))
 #endif
 
 namespace grpc_labview 


### PR DESCRIPTION
This PR is to update the Linux build to only export LIBRARY_EXPORT symbols from the shared library.

Currently the labview grpc shared library for Linux exports all symbols. This causes symbol collisions for some use case.  For example, the liblabview_grpc_server.so exports the following unique symbols (you can see the full list by running the `nm -C -D liblabview_grpc_server.so` command)
```
0000000000b3ef88 u grpc::internal::GrpcLibraryInitializer::GrpcLibraryInitializer()::g_core_codegen
0000000000b3ef98 u grpc::internal::GrpcLibraryInitializer::GrpcLibraryInitializer()::g_gli
```
If in a labview app that uses grpc-labview, it calls another C library that also uses grpc which also exports the above symbols, there will be collisions.  

To avoid that issues, we should update the Linux build (include both Desktop and RT) to only export `LIBRARY_EXPORT `symbols from the shared library. We already do this for the Windows build.


