### PR TITLE
Changes to Better Support Asynchronous Server Shutdown

### DIFF
--- a/src/any_support.cc
+++ b/src/any_support.cc
@@ -139,6 +139,7 @@ LIBRARY_EXPORT int32_t TryUnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::
     {
         return -2;
     }
+
     if (grpc_labview::GetLVString(anyCluster->TypeUrl) != messageType)
     {
         return -1;
@@ -157,6 +158,11 @@ LIBRARY_EXPORT int32_t IsAnyOfType(grpc_labview::gRPCid* id, grpc_labview::AnyCl
     }
 
     auto metadata = metadataOwner->FindMetadata(messageType);
+    if (metadata == nullptr)
+    {
+        return -2;
+    }
+
     if (grpc_labview::GetLVString(anyCluster->TypeUrl) != metadata->typeUrl)
     {
         return -1;

--- a/src/any_support.cc
+++ b/src/any_support.cc
@@ -31,6 +31,11 @@ LIBRARY_EXPORT int32_t FreeSerializationSession(grpc_labview::gRPCid* sessionId)
 LIBRARY_EXPORT int32_t PackToBuffer(grpc_labview::gRPCid* id, const char* messageType, int8_t* cluster, grpc_labview::LV1DArrayHandle* lvBuffer)
 {
     auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+    if (!metadataOwner)
+    {
+        return -1;
+    }
+
     auto metadata = metadataOwner->FindMetadata(messageType);
     if (metadata == nullptr)
     {
@@ -63,6 +68,11 @@ LIBRARY_EXPORT int32_t PackToBuffer(grpc_labview::gRPCid* id, const char* messag
 LIBRARY_EXPORT int32_t PackToAny(grpc_labview::gRPCid* id, const char* messageType, int8_t* cluster, grpc_labview::AnyCluster* anyCluster)
 {
     auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+    if (!metadataOwner)
+    {
+        return -1;
+    }
+
     auto metadata = metadataOwner->FindMetadata(messageType);
     if (metadata == nullptr)
     {
@@ -78,12 +88,17 @@ LIBRARY_EXPORT int32_t PackToAny(grpc_labview::gRPCid* id, const char* messageTy
 LIBRARY_EXPORT int32_t UnpackFromBuffer(grpc_labview::gRPCid* id, grpc_labview::LV1DArrayHandle lvBuffer, const char* messageType, int8_t* cluster)
 {
     auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    auto metadata = metadataOwner->FindMetadata(messageType);
+    if (!metadataOwner)
+    {
+        return -1;
+    }
 
+    auto metadata = metadataOwner->FindMetadata(messageType);
     if (metadata == nullptr)
     {
         return -2;
-    }  
+    }
+
     grpc_labview::LVMessage message(metadata);
     char* elements = (*lvBuffer)->bytes<char>();
     std::string buffer(elements, (*lvBuffer)->cnt);
@@ -112,10 +127,14 @@ LIBRARY_EXPORT int32_t UnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::Any
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t TryUnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::AnyCluster* anyCluster, const char* messageType, int8_t* cluster)
-{    
+{
     auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    auto metadata = metadataOwner->FindMetadata(messageType);
+    if (!metadataOwner)
+    {
+        return -1;
+    }
 
+    auto metadata = metadataOwner->FindMetadata(messageType);
     if (metadata == nullptr)
     {
         return -2;
@@ -130,10 +149,14 @@ LIBRARY_EXPORT int32_t TryUnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t IsAnyOfType(grpc_labview::gRPCid* id, grpc_labview::AnyCluster* anyCluster, const char* messageType)
-{    
+{
     auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    auto metadata = metadataOwner->FindMetadata(messageType);
+    if (!metadataOwner)
+    {
+        return -1;
+    }
 
+    auto metadata = metadataOwner->FindMetadata(messageType);
     if (grpc_labview::GetLVString(anyCluster->TypeUrl) != metadata->typeUrl)
     {
         return -1;
@@ -144,14 +167,14 @@ LIBRARY_EXPORT int32_t IsAnyOfType(grpc_labview::gRPCid* id, grpc_labview::AnyCl
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBegin(grpc_labview::gRPCid** builderId)
-{   
+{
     grpc_labview::InitCallbacks();
 
     auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
     auto rootMessage = new grpc_labview::LVMessage(metadata);
     grpc_labview::gPointerManager.RegisterPointer(rootMessage);
     *builderId = rootMessage;
-    return 0; 
+    return 0;
 }
 
 //---------------------------------------------------------------------
@@ -159,6 +182,11 @@ LIBRARY_EXPORT int32_t AnyBuilderBegin(grpc_labview::gRPCid** builderId)
 LIBRARY_EXPORT int32_t AnyBuilderAddValue(grpc_labview::gRPCid* anyId, grpc_labview::LVMessageMetadataType valueType, int isRepeated, int protobufIndex, int8_t* value)
 {
     auto message = anyId->CastTo<grpc_labview::LVMessage>();
+    if (!message)
+    {
+        return -1;
+    }
+
     try
     {
         grpc_labview::ClusterDataCopier::AnyBuilderAddValue(*message, valueType, isRepeated, protobufIndex, value);
@@ -173,48 +201,66 @@ LIBRARY_EXPORT int32_t AnyBuilderAddValue(grpc_labview::gRPCid* anyId, grpc_labv
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginNestedMessage(grpc_labview::gRPCid* builderId, int protobufIndex, grpc_labview::gRPCid** nestedId)
-{   
+{
     auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+    if (!message)
+    {
+        return -1;
+    }
 
+    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
     auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
     auto value = std::make_shared<grpc_labview::LVNestedMessageMessageValue>(protobufIndex, nested);
     message->_values.emplace(protobufIndex, value);
     *nestedId = nested.get();
-    return 0; 
+    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginRepeatedNestedMessage(grpc_labview::gRPCid* builderId, int protobufIndex, grpc_labview::gRPCid** nestedId)
-{   
+{
     auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+    if (!message)
+    {
+        return -1;
+    }
 
+    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
     auto value = std::make_shared<grpc_labview::LVRepeatedNestedMessageMessageValue>(protobufIndex);
     message->_values.emplace(protobufIndex, value);
     *nestedId = value.get();
-    return 0; 
+    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginRepeatedNestedMessageElement(grpc_labview::gRPCid* builderId, grpc_labview::gRPCid** nestedId)
-{   
+{
     auto message = builderId->CastTo<grpc_labview::LVRepeatedNestedMessageMessageValue>();
+    if (!message)
+    {
+        return -1;
+    }
+
     auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
 
     auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
     message->_value.emplace_back(nested);
     *nestedId = nested.get();
-    return 0; 
+    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBuildToBuffer(grpc_labview::gRPCid* builderId, const char* typeUrl, grpc_labview::LV1DArrayHandle* lvBuffer)
-{   
+{
     auto message = builderId->CastTo<grpc_labview::LVMessage>();
+    if (!message)
+    {
+        return -1;
+    }
+
     grpc_labview::gPointerManager.UnregisterPointer(builderId);
     std::string buffer;
     if (message->SerializeToString(&buffer))
@@ -231,8 +277,13 @@ LIBRARY_EXPORT int32_t AnyBuilderBuildToBuffer(grpc_labview::gRPCid* builderId, 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBuild(grpc_labview::gRPCid* builderId, const char* typeUrl, grpc_labview::AnyCluster* anyCluster)
-{   
+{
     auto message = builderId->CastTo<grpc_labview::LVMessage>();
+    if (!message)
+    {
+        return -1;
+    }
+
     grpc_labview::SetLVString(&anyCluster->TypeUrl, message->_metadata->typeUrl);
     return AnyBuilderBuildToBuffer(builderId, typeUrl, &anyCluster->Bytes);
 }

--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -345,6 +345,12 @@ LIBRARY_EXPORT int32_t SetResponseData(grpc_labview::gRPCid** id, int8_t* lvRequ
     {
         return -1;
     }
+
+    if (data->_call->IsCancelled())
+    {
+        return -(1000 + grpc::StatusCode::CANCELLED);
+    }
+
     try
     {
         grpc_labview::ClusterDataCopier::CopyFromCluster(*data->_response, lvRequest);
@@ -353,10 +359,7 @@ LIBRARY_EXPORT int32_t SetResponseData(grpc_labview::gRPCid** id, int8_t* lvRequ
     {
         return e.code;
     }
-    if (data->_call->IsCancelled())
-    {
-        return -(1000 + grpc::StatusCode::CANCELLED);
-    }
+
     if (!data->_call->IsActive() || !data->_call->Write())
     {
         return -2;
@@ -373,6 +376,12 @@ LIBRARY_EXPORT int32_t CloseServerEvent(grpc_labview::gRPCid** id)
     {
         return -1;
     }
+
+    if (data->_call->IsCancelled())
+    {
+        return -(1000 + grpc::StatusCode::CANCELLED);
+    }
+
     data->NotifyComplete();
     data->_call->Finish();
     grpc_labview::gPointerManager.UnregisterPointer(*id);

--- a/src/unpacked_fields.cc
+++ b/src/unpacked_fields.cc
@@ -13,7 +13,7 @@ namespace grpc_labview
     class UnpackedFields : public gRPCid
     {
     public:
-        UnpackedFields(LVMessage* message);    
+        UnpackedFields(LVMessage* message);
         int32_t GetField(int protobufIndex, LVMessageMetadataType valueType, int isRepeated, int8_t* buffer);
 
     private:
@@ -124,7 +124,7 @@ namespace grpc_labview
                 arr[i] = val;
             }
 
-            // Memcopy the unsigned integer array (arr) into the labview array (destArray). 
+            // Memcopy the unsigned integer array (arr) into the labview array (destArray).
             grpc_labview::NumericArrayResize(typeCode, 1, destArray, count);
             (**destArray)->cnt = count;
             memcpy((**destArray)->bytes<T>(), arr, count * sizeof(T));
@@ -206,8 +206,8 @@ namespace grpc_labview
                     SetLVString((LStrHandle*)buffer, field->length_delimited());
                 }
                 break;
-        }    
-        return 0; 
+        }
+        return 0;
     }
 }
 
@@ -244,16 +244,22 @@ LIBRARY_EXPORT int32_t GetUnpackedField(grpc_labview::gRPCid* id, int protobufIn
     {
         return -1;
     }
+
     auto unpackedFields = id->CastTo<grpc_labview::UnpackedFields>();
+    if (!unpackedFields)
+    {
+        return -1;
+    }
+
     unpackedFields->GetField(protobufIndex, valueType, isRepeated, buffer);
-    return 0; 
+    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t GetUnpackedMessageField(grpc_labview::gRPCid* id, int protobufIndex, int8_t* buffer)
-{    
-    return -1; 
+{
+    return -1;
 }
 
 //---------------------------------------------------------------------
@@ -261,5 +267,5 @@ LIBRARY_EXPORT int32_t GetUnpackedMessageField(grpc_labview::gRPCid* id, int pro
 LIBRARY_EXPORT int32_t FreeUnpackedFields(grpc_labview::gRPCid* id)
 {
     grpc_labview::gPointerManager.UnregisterPointer(id);
-    return 0; 
+    return 0;
 }


### PR DESCRIPTION
# Description
This PR better supports server shutdown when there are outstanding RPCs at the time of shutdown.

# Implementation / Design
- All exported APIs now first verify that the registered pointer passed in (gRPCid) is valid before using it and return an error if it is not valid. This was done predominantly for the pack/unpack APIs since they can reference the server object as the metadata owner. However, it was applied to all exported APIs for consistency.
- Updated `SetResponseData` and `CloseServerEvent` so they first check to see if the call has been canceled before trying to call into the underlying infrastructure to complete the call. This is necessary because the call object holds onto pointers to objects owned by the server, but the call lifetime is not tied to the server lifetime. This results in accessing a deleted pointer unless the call first checks for cancellation. I briefly considered changing the pointers to smart pointers instead as a more holistic solution. However, that would result in the server (and other `IMessageElementMetadataOwner` objects) holding onto message metadata which contained a smart pointer back to itself which didn't seem ideal.

# Testing
I manually tested using a service that arbitrarily added a ten second wait to the RPC before returning. I then shutdown the server after a client unary call was in progress but before it completed.