### PR TITLE
Change const to constexpr so that symbols are resolved

### DIFF
--- a/src/well_known_messages.h
+++ b/src/well_known_messages.h
@@ -49,9 +49,9 @@ namespace grpc_labview
             virtual ~I2DArray() = default;
 
         protected:
-            static const int _rowsIndex = 1;
-            static const int _columnsIndex = 2;
-            static const int _dataIndex = 3;
+            static constexpr int _rowsIndex = 1;
+            static constexpr int _columnsIndex = 2;
+            static constexpr int _dataIndex = 3;
         };
 
         //---------------------------------------------------------------------


### PR DESCRIPTION
As discussed in #441 - this update allows these const int variables to be defined.  Previously, using the shared library on Linux RT resulted in error 13 from LabVIEW and 3 symbols were not defined.

Fixes #441 