### PR TITLE
Remove installation of visualstudio2022-workload-vctools during build

### DIFF
--- a/.github/workflows/windows_x64_build.yml
+++ b/.github/workflows/windows_x64_build.yml
@@ -21,20 +21,6 @@ jobs:
     - uses: ilammy/msvc-dev-cmd@v1
     - uses: ilammy/setup-nasm@v1.5.1
 
-    - name: Install Visual Studio 2022 Build Tools
-      shell: pwsh
-      run: |
-        choco install visualstudio2022-workload-vctools --yes
-        if ($LASTEXITCODE -eq 3010) {
-            # Trap and ignore error 3010
-            Write-Host "Installation successful, reboot required.  Ignoring and proceeding..."
-            exit 0
-        } elseif ($LASTEXITCODE -ne 0) {
-            # If another error happened (that wasn't 3010), then pass that error up
-            Write-Error "Installation failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
-
     - name: Update Submodules
       working-directory: ${{runner.workspace}}/grpc-labview      
       run: git submodule update --init --recursive

--- a/.github/workflows/windows_x64_build.yml
+++ b/.github/workflows/windows_x64_build.yml
@@ -22,8 +22,18 @@ jobs:
     - uses: ilammy/setup-nasm@v1.5.1
 
     - name: Install Visual Studio 2022 Build Tools
+      shell: pwsh
       run: |
-        choco install visualstudio2022-workload-vctools --yes || throw "Installation failed"
+        choco install visualstudio2022-workload-vctools --yes
+        if ($LASTEXITCODE -eq 3010) {
+            # Trap and ignore error 3010
+            Write-Host "Installation successful, reboot required.  Ignoring and proceeding..."
+            exit 0
+        } elseif ($LASTEXITCODE -ne 0) {
+            # If another error happened (that wasn't 3010), then pass that error up
+            Write-Error "Installation failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
 
     - name: Update Submodules
       working-directory: ${{runner.workspace}}/grpc-labview      

--- a/.github/workflows/windows_x86_build.yml
+++ b/.github/workflows/windows_x86_build.yml
@@ -18,20 +18,6 @@ jobs:
         arch: x86
     - uses: ilammy/setup-nasm@v1.5.1
 
-    - name: Install Visual Studio 2022 Build Tools
-      shell: pwsh
-      run: |
-        choco install visualstudio2022-workload-vctools --yes
-        if ($LASTEXITCODE -eq 3010) {
-            # Trap and ignore error 3010
-            Write-Host "Installation successful, reboot required.  Ignoring and proceeding..."
-            exit 0
-        } elseif ($LASTEXITCODE -ne 0) {
-            # If another error happened (that wasn't 3010), then pass that error up
-            Write-Error "Installation failed with exit code $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
-
     - name: Update Submodules
       working-directory: ${{runner.workspace}}/grpc-labview      
       run: git submodule update --init --recursive

--- a/.github/workflows/windows_x86_build.yml
+++ b/.github/workflows/windows_x86_build.yml
@@ -19,12 +19,17 @@ jobs:
     - uses: ilammy/setup-nasm@v1.5.1
 
     - name: Install Visual Studio 2022 Build Tools
+      shell: pwsh
       run: |
         choco install visualstudio2022-workload-vctools --yes
         if ($LASTEXITCODE -eq 3010) {
+            # Trap and ignore error 3010
             Write-Host "Installation successful, reboot required.  Ignoring and proceeding..."
+            exit 0
         } elseif ($LASTEXITCODE -ne 0) {
+            # If another error happened (that wasn't 3010), then pass that error up
             Write-Error "Installation failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
         }
 
     - name: Update Submodules

--- a/.github/workflows/windows_x86_build.yml
+++ b/.github/workflows/windows_x86_build.yml
@@ -20,7 +20,12 @@ jobs:
 
     - name: Install Visual Studio 2022 Build Tools
       run: |
-        choco install visualstudio2022-workload-vctools --yes || throw "Installation failed"
+        choco install visualstudio2022-workload-vctools --yes
+        if ($LASTEXITCODE -eq 3010) {
+            Write-Host "Installation successful, reboot required.  Ignoring and proceeding..."
+        } elseif ($LASTEXITCODE -ne 0) {
+            Write-Error "Installation failed with exit code $LASTEXITCODE"
+        }
 
     - name: Update Submodules
       working-directory: ${{runner.workspace}}/grpc-labview      


### PR DESCRIPTION
Starting recently, the choco package visualstudio2022-workload-vctools requests a reboot during install on a Github runner while running the x86/x64 build actions.

Because the Github `windows-2022` runner already includes Visual Studio 2022, installation of `visualstudio2022-workload-vctools` is not required.  Both the x86 and x64 builds are successful without this installation step.


Previously, the build output shows (and fails with error 3010)
```
visualstudio2022-workload-vctools v1.0.0 [Approved] - Possibly broken
visualstudio2022-workload-vctools package files install completed. Performing other installation steps.
Installing visualstudio2022-workload-vctools...

WARNING: visualstudio2022-workload-vctools has been installed. However, a reboot is required to finalize the installation.
WARNING: visualstudio2022-workload-vctools has been installed. However, a reboot is required to finalize the installation.
  visualstudio2022-workload-vctools may be able to be automatically uninstalled.
 The install of visualstudio2022-workload-vctools was successful.
  Software install location not explicitly set, it could be in package or
  default install location of installer.

Chocolatey installed 6/6 packages. 
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Installed:
 - chocolatey-dotnetfx.extension v1.0.1
 - chocolatey-visualstudio.extension v1.11.1
 - dotnetfx v4.8.0.20220524
 - visualstudio2022buildtools v117.14.0
 - visualstudio2022-workload-vctools v1.0.0
 - visualstudio-installer v2.0.3

Packages requiring reboot:
 - visualstudio2022-workload-vctools (exit code 3010)

The recent package changes indicate a reboot is necessary.
 Please reboot at your earliest convenience.

```