### PR TITLE
fix: Update all exported library functions to catch and translate C++ exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(labview_grpc_server SHARED
   src/any_support.cc
   src/cluster_copier.cc
   src/event_data.cc
+  src/exceptions.cc
   src/feature_toggles.cc
   src/grpc_client.cc
   src/grpc_interop.cc
@@ -110,6 +111,7 @@ target_link_libraries(labview_grpc_server
 # server VIs from a .proto file
 #----------------------------------------------------------------------
 add_library(labview_grpc_generator SHARED
+  src/exceptions.cc
   src/feature_toggles.cc
   src/lv_interop.cc
   src/path_support.cc

--- a/src/any_support.cc
+++ b/src/any_support.cc
@@ -10,286 +10,326 @@
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t CreateSerializationSession(grpc_labview::gRPCid** sessionId)
 {
-    grpc_labview::InitCallbacks();
-    auto session = new grpc_labview::LabVIEWSerializationSession();
-    grpc_labview::gPointerManager.RegisterPointer(session);
-    *sessionId = session;
-    return 0;
+    try {
+        grpc_labview::InitCallbacks();
+        auto session = new grpc_labview::LabVIEWSerializationSession();
+        grpc_labview::gPointerManager.RegisterPointer(session);
+        *sessionId = session;
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t FreeSerializationSession(grpc_labview::gRPCid* sessionId)
 {
-    auto session = sessionId->CastTo<grpc_labview::LabVIEWSerializationSession>();
-    grpc_labview::gPointerManager.UnregisterPointer(sessionId);
-    return 0;
+    try {
+        auto session = sessionId->CastTo<grpc_labview::LabVIEWSerializationSession>();
+        grpc_labview::gPointerManager.UnregisterPointer(sessionId);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t PackToBuffer(grpc_labview::gRPCid* id, const char* messageType, int8_t* cluster, grpc_labview::LV1DArrayHandle* lvBuffer)
 {
-    auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    if (!metadataOwner)
-    {
-        return -1;
-    }
+    try {
+        auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+        if (!metadataOwner)
+        {
+            return -1;
+        }
 
-    auto metadata = metadataOwner->FindMetadata(messageType);
-    if (metadata == nullptr)
-    {
-        return -2;
-    }
+        auto metadata = metadataOwner->FindMetadata(messageType);
+        if (metadata == nullptr)
+        {
+            return -2;
+        }
 
-    grpc_labview::LVMessage message(metadata);
-    try
-    {
+        grpc_labview::LVMessage message(metadata);
         grpc_labview::ClusterDataCopier::CopyFromCluster(message, cluster);
+
+        std::string buffer;
+        if (message.SerializeToString(&buffer))
+        {
+            NumericArrayResize(0x01, 1, lvBuffer, buffer.length());
+            (**lvBuffer)->cnt = buffer.length();
+            uint8_t* elements = (**lvBuffer)->bytes<uint8_t>();
+            memcpy(elements, buffer.c_str(), buffer.length());
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    catch (grpc_labview::InvalidEnumValueException& e)
-    {
-        return e.code;
-    }
-    std::string buffer;
-    if (message.SerializeToString(&buffer))
-    {
-        NumericArrayResize(0x01, 1, lvBuffer, buffer.length());
-        (**lvBuffer)->cnt = buffer.length();
-        uint8_t* elements = (**lvBuffer)->bytes<uint8_t>();
-        memcpy(elements, buffer.c_str(), buffer.length());
-        return 0;
-    }
-    return -2;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t PackToAny(grpc_labview::gRPCid* id, const char* messageType, int8_t* cluster, grpc_labview::AnyCluster* anyCluster)
 {
-    auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    if (!metadataOwner)
-    {
-        return -1;
-    }
+    try {
+        auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+        if (!metadataOwner)
+        {
+            return -1;
+        }
 
-    auto metadata = metadataOwner->FindMetadata(messageType);
-    if (metadata == nullptr)
-    {
-        return -2;
-    }
+        auto metadata = metadataOwner->FindMetadata(messageType);
+        if (metadata == nullptr)
+        {
+            return -2;
+        }
 
-    SetLVString(&anyCluster->TypeUrl, "/" + metadata->typeUrl);
-    return PackToBuffer(id, messageType, cluster, &anyCluster->Bytes);
+        SetLVString(&anyCluster->TypeUrl, "/" + metadata->typeUrl);
+        return PackToBuffer(id, messageType, cluster, &anyCluster->Bytes);
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t UnpackFromBuffer(grpc_labview::gRPCid* id, grpc_labview::LV1DArrayHandle lvBuffer, const char* messageType, int8_t* cluster)
 {
-    auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    if (!metadataOwner)
-    {
-        return -1;
-    }
+    try {
+        auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+        if (!metadataOwner)
+        {
+            return -1;
+        }
 
-    auto metadata = metadataOwner->FindMetadata(messageType);
-    if (metadata == nullptr)
-    {
-        return -2;
-    }
+        auto metadata = metadataOwner->FindMetadata(messageType);
+        if (metadata == nullptr)
+        {
+            return -2;
+        }
 
-    grpc_labview::LVMessage message(metadata);
-    char* elements = (*lvBuffer)->bytes<char>();
-    std::string buffer(elements, (*lvBuffer)->cnt);
-    if (message.ParseFromString(buffer))
-    {
-        try
+        grpc_labview::LVMessage message(metadata);
+        char* elements = (*lvBuffer)->bytes<char>();
+        std::string buffer(elements, (*lvBuffer)->cnt);
+        if (message.ParseFromString(buffer))
         {
             grpc_labview::ClusterDataCopier::CopyToCluster(message, cluster);
+            return 0;
         }
-        catch (grpc_labview::InvalidEnumValueException& e)
-        {
-            return e.code;
-        }
-        return 0;
+        return -2;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return -2;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t UnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::AnyCluster* anyCluster, const char* messageType, int8_t* cluster)
 {
-    return UnpackFromBuffer(id, anyCluster->Bytes, messageType, cluster);
+    try {
+        return UnpackFromBuffer(id, anyCluster->Bytes, messageType, cluster);
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t TryUnpackFromAny(grpc_labview::gRPCid* id, grpc_labview::AnyCluster* anyCluster, const char* messageType, int8_t* cluster)
 {
-    auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    if (!metadataOwner)
-    {
-        return -1;
-    }
+    try {
+        auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+        if (!metadataOwner)
+        {
+            return -1;
+        }
 
-    auto metadata = metadataOwner->FindMetadata(messageType);
-    if (metadata == nullptr)
-    {
-        return -2;
-    }
+        auto metadata = metadataOwner->FindMetadata(messageType);
+        if (metadata == nullptr)
+        {
+            return -2;
+        }
 
-    if (grpc_labview::GetLVString(anyCluster->TypeUrl) != messageType)
-    {
-        return -1;
+        if (grpc_labview::GetLVString(anyCluster->TypeUrl) != messageType)
+        {
+            return -1;
+        }
+        return UnpackFromBuffer(id, anyCluster->Bytes, messageType, cluster);
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return UnpackFromBuffer(id, anyCluster->Bytes, messageType, cluster);
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t IsAnyOfType(grpc_labview::gRPCid* id, grpc_labview::AnyCluster* anyCluster, const char* messageType)
 {
-    auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
-    if (!metadataOwner)
-    {
-        return -1;
-    }
+    try {
+        auto metadataOwner = id->CastTo<grpc_labview::IMessageElementMetadataOwner>();
+        if (!metadataOwner)
+        {
+            return -1;
+        }
 
-    auto metadata = metadataOwner->FindMetadata(messageType);
-    if (metadata == nullptr)
-    {
-        return -2;
-    }
+        auto metadata = metadataOwner->FindMetadata(messageType);
+        if (metadata == nullptr)
+        {
+            return -2;
+        }
 
-    if (grpc_labview::GetLVString(anyCluster->TypeUrl) != metadata->typeUrl)
-    {
-        return -1;
+        if (grpc_labview::GetLVString(anyCluster->TypeUrl) != metadata->typeUrl)
+        {
+            return -1;
+        }
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBegin(grpc_labview::gRPCid** builderId)
 {
-    grpc_labview::InitCallbacks();
+    try {
+        grpc_labview::InitCallbacks();
 
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
-    auto rootMessage = new grpc_labview::LVMessage(metadata);
-    grpc_labview::gPointerManager.RegisterPointer(rootMessage);
-    *builderId = rootMessage;
-    return 0;
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+        auto rootMessage = new grpc_labview::LVMessage(metadata);
+        grpc_labview::gPointerManager.RegisterPointer(rootMessage);
+        *builderId = rootMessage;
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderAddValue(grpc_labview::gRPCid* anyId, grpc_labview::LVMessageMetadataType valueType, int isRepeated, int protobufIndex, int8_t* value)
 {
-    auto message = anyId->CastTo<grpc_labview::LVMessage>();
-    if (!message)
-    {
-        return -1;
-    }
+    try {
+        auto message = anyId->CastTo<grpc_labview::LVMessage>();
+        if (!message)
+        {
+            return -1;
+        }
 
-    try
-    {
         grpc_labview::ClusterDataCopier::AnyBuilderAddValue(*message, valueType, isRepeated, protobufIndex, value);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    catch (grpc_labview::InvalidEnumValueException& e)
-    {
-        return e.code;
-    }
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginNestedMessage(grpc_labview::gRPCid* builderId, int protobufIndex, grpc_labview::gRPCid** nestedId)
 {
-    auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    if (!message)
-    {
-        return -1;
-    }
+    try {
+        auto message = builderId->CastTo<grpc_labview::LVMessage>();
+        if (!message)
+        {
+            return -1;
+        }
 
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
-    auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
-    auto value = std::make_shared<grpc_labview::LVNestedMessageMessageValue>(protobufIndex, nested);
-    message->_values.emplace(protobufIndex, value);
-    *nestedId = nested.get();
-    return 0;
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+        auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
+        auto value = std::make_shared<grpc_labview::LVNestedMessageMessageValue>(protobufIndex, nested);
+        message->_values.emplace(protobufIndex, value);
+        *nestedId = nested.get();
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginRepeatedNestedMessage(grpc_labview::gRPCid* builderId, int protobufIndex, grpc_labview::gRPCid** nestedId)
 {
-    auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    if (!message)
-    {
-        return -1;
-    }
+    try {
+        auto message = builderId->CastTo<grpc_labview::LVMessage>();
+        if (!message)
+        {
+            return -1;
+        }
 
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
-    auto value = std::make_shared<grpc_labview::LVRepeatedNestedMessageMessageValue>(protobufIndex);
-    message->_values.emplace(protobufIndex, value);
-    *nestedId = value.get();
-    return 0;
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+        auto value = std::make_shared<grpc_labview::LVRepeatedNestedMessageMessageValue>(protobufIndex);
+        message->_values.emplace(protobufIndex, value);
+        *nestedId = value.get();
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBeginRepeatedNestedMessageElement(grpc_labview::gRPCid* builderId, grpc_labview::gRPCid** nestedId)
 {
-    auto message = builderId->CastTo<grpc_labview::LVRepeatedNestedMessageMessageValue>();
-    if (!message)
-    {
-        return -1;
+    try {
+        auto message = builderId->CastTo<grpc_labview::LVRepeatedNestedMessageMessageValue>();
+        if (!message)
+        {
+            return -1;
+        }
+
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
+
+        auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
+        message->_value.emplace_back(nested);
+        *nestedId = nested.get();
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>();
-
-    auto nested = std::make_shared<grpc_labview::LVMessage>(metadata);
-    message->_value.emplace_back(nested);
-    *nestedId = nested.get();
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBuildToBuffer(grpc_labview::gRPCid* builderId, const char* typeUrl, grpc_labview::LV1DArrayHandle* lvBuffer)
 {
-    auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    if (!message)
-    {
-        return -1;
-    }
+    try {
+        auto message = builderId->CastTo<grpc_labview::LVMessage>();
+        if (!message)
+        {
+            return -1;
+        }
 
-    grpc_labview::gPointerManager.UnregisterPointer(builderId);
-    std::string buffer;
-    if (message->SerializeToString(&buffer))
-    {
-        grpc_labview::NumericArrayResize(0x01, 1, lvBuffer, buffer.length());
-        (**lvBuffer)->cnt = buffer.length();
-        uint8_t* elements = (**lvBuffer)->bytes<uint8_t>();
-        memcpy(elements, buffer.c_str(), buffer.length());
-        return 0;
+        grpc_labview::gPointerManager.UnregisterPointer(builderId);
+        std::string buffer;
+        if (message->SerializeToString(&buffer))
+        {
+            grpc_labview::NumericArrayResize(0x01, 1, lvBuffer, buffer.length());
+            (**lvBuffer)->cnt = buffer.length();
+            uint8_t* elements = (**lvBuffer)->bytes<uint8_t>();
+            memcpy(elements, buffer.c_str(), buffer.length());
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return -2;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t AnyBuilderBuild(grpc_labview::gRPCid* builderId, const char* typeUrl, grpc_labview::AnyCluster* anyCluster)
 {
-    auto message = builderId->CastTo<grpc_labview::LVMessage>();
-    if (!message)
-    {
-        return -1;
-    }
+    try {
+        auto message = builderId->CastTo<grpc_labview::LVMessage>();
+        if (!message)
+        {
+            return -1;
+        }
 
-    grpc_labview::SetLVString(&anyCluster->TypeUrl, message->_metadata->typeUrl);
-    return AnyBuilderBuildToBuffer(builderId, typeUrl, &anyCluster->Bytes);
+        grpc_labview::SetLVString(&anyCluster->TypeUrl, message->_metadata->typeUrl);
+        return AnyBuilderBuildToBuffer(builderId, typeUrl, &anyCluster->Bytes);
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }

--- a/src/exceptions.cc
+++ b/src/exceptions.cc
@@ -1,0 +1,41 @@
+#include "exceptions.h"
+
+#include <iostream>
+
+namespace grpc_labview
+{
+    int32_t TranslateException() {
+        try {
+            throw;
+        }
+        catch (const GrpcException& e) {
+#ifndef NDEBUG
+            std::cerr << "gRPC ERROR: " << e.GetStatusCode() << " - " << e.what() << std::endl;
+#endif
+            return -(1000 + e.GetStatusCode());
+        }
+        catch (const LabVIEWException& e) {
+#ifndef NDEBUG
+            std::cerr << "LabVIEW ERROR: " << e.GetCode() << " - " << e.what() << std::endl;
+#endif
+            return e.GetCode();
+        }
+        catch (const std::exception& e) {
+#ifndef NDEBUG
+            std::cerr << "ERROR: " << e.what() << std::endl;
+#endif
+            return -1;
+        }
+    }
+
+    void SetErrorMessage(LStrHandle* errorMessageOut, const char* message) {
+        if (!errorMessageOut) return;
+        if (!message) message = "";
+
+        try {
+            SetLVString(errorMessageOut, message);
+        } catch (const std::exception&) {
+            // Ignore errors
+        }
+    }
+}

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -2,18 +2,45 @@
 //---------------------------------------------------------------------
 #pragma once
 
+#include <cstdint>
+#include <grpcpp/support/status.h>
+#include <lv_interop.h>
+#include <stdexcept>
+#include <string>
+
 namespace grpc_labview
 {
-    class InvalidEnumValueException : public std::exception {
-    private:
-        char* message;
-
+    class GrpcException : public std::runtime_error {
     public:
-        InvalidEnumValueException(char* msg) : message(msg) {}
-        char* what()
-        {
-            return message;
-        }
-        const int code = -2003; // Essentially, -(1000 + grpc::StatusCode::INVALID_ARGUMENT);, but 2000 instead of 1000 because it's not a gRPC eror, more of an LV error.
+        GrpcException(grpc::StatusCode code, const std::string& message) : std::runtime_error(message), _code(code) {}
+        GrpcException(grpc::StatusCode code, const char* message) : std::runtime_error(message), _code(code) {}
+        GrpcException(const GrpcException& other) : std::runtime_error(other.what()), _code(other._code) {}
+
+        grpc::Status GetStatus() const { return grpc::Status(_code, what()); }
+        grpc::StatusCode GetStatusCode() const { return _code; }
+
+    private:
+        grpc::StatusCode _code;
     };
+
+    class LabVIEWException : public std::runtime_error {
+    public:
+        LabVIEWException(int32_t code, const std::string& message) : std::runtime_error(message), _code(code) {}
+        LabVIEWException(int32_t code, const char* message) : std::runtime_error(message), _code(code) {}
+        LabVIEWException(const LabVIEWException& other) : std::runtime_error(other.what()), _code(other._code) {}
+
+        int32_t GetCode() const { return _code; }
+
+    private:
+        int32_t _code;
+    };
+
+    class InvalidEnumValueException : public LabVIEWException {
+    public:
+        InvalidEnumValueException(const char* message) : LabVIEWException(-2003, message) {}
+    };
+
+    int32_t TranslateException();
+
+    void SetErrorMessage(LStrHandle* errorMessageOut, const char* message);
 }

--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -131,61 +131,81 @@ int32_t ServerCleanupProc(grpc_labview::gRPCid* serverId);
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t IsFeatureEnabled(const char* featureName, uint8_t* featureEnabled)
 {
-    *featureEnabled = grpc_labview::FeatureConfig::getInstance().IsFeatureEnabled(featureName);
-    return 0;
+    try {
+        *featureEnabled = grpc_labview::FeatureConfig::getInstance().IsFeatureEnabled(featureName);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t LVCreateServer(grpc_labview::gRPCid** id)
 {
-    grpc_labview::InitCallbacks();
-    auto server = new grpc_labview::LabVIEWgRPCServer();
-    grpc_labview::gPointerManager.RegisterPointer(server);
-    *id = server;
-    grpc_labview::RegisterCleanupProc(ServerCleanupProc, server);
-    return 0;
+    try {
+        grpc_labview::InitCallbacks();
+        auto server = new grpc_labview::LabVIEWgRPCServer();
+        grpc_labview::gPointerManager.RegisterPointer(server);
+        *id = server;
+        grpc_labview::RegisterCleanupProc(ServerCleanupProc, server);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t LVStartServer(char* address, char* serverCertificatePath, char* serverKeyPath, grpc_labview::gRPCid** id)
 {
-    auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        return server->Run(address, serverCertificatePath, serverKeyPath);
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return server->Run(address, serverCertificatePath, serverKeyPath);
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t LVGetServerListeningPort(grpc_labview::gRPCid** id, int* listeningPort)
 {
-    auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        *listeningPort = server->ListeningPort();
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    *listeningPort = server->ListeningPort();
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t LVStopServer(grpc_labview::gRPCid** id)
 {
-    auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
-    if (server == nullptr)
-    {
-        return -1;
-    }
-    server->StopServer();
+    try {
+        auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        server->StopServer();
 
-    grpc_labview::DeregisterCleanupProc(ServerCleanupProc, *id);
-    grpc_labview::gPointerManager.UnregisterPointer(server.get());
-    return 0;
+        grpc_labview::DeregisterCleanupProc(ServerCleanupProc, *id);
+        grpc_labview::gPointerManager.UnregisterPointer(server.get());
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 int32_t ServerCleanupProc(grpc_labview::gRPCid* serverId)
@@ -197,221 +217,266 @@ int32_t ServerCleanupProc(grpc_labview::gRPCid* serverId)
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t RegisterMessageMetadata(grpc_labview::gRPCid** id, grpc_labview::LVMessageMetadata* lvMetadata)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>(server.get(), lvMetadata);
+        server->RegisterMetadata(metadata);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>(server.get(), lvMetadata);
-    server->RegisterMetadata(metadata);
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t RegisterMessageMetadata2(grpc_labview::gRPCid** id, grpc_labview::LVMessageMetadata2* lvMetadata)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        auto metadata = std::make_shared<grpc_labview::MessageMetadata>(server.get(), lvMetadata);
+        server->RegisterMetadata(metadata);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    auto metadata = std::make_shared<grpc_labview::MessageMetadata>(server.get(), lvMetadata);
-    server->RegisterMetadata(metadata);
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t RegisterEnumMetadata2(grpc_labview::gRPCid** id, grpc_labview::LVEnumMetadata2* lvMetadata)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        auto metadata = CreateEnumMetadata2(server.get(), lvMetadata);
+        server->RegisterMetadata(metadata);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    auto metadata = CreateEnumMetadata2(server.get(), lvMetadata);
-    server->RegisterMetadata(metadata);
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT uint32_t GetLVEnumValueFromProtoValue(grpc_labview::gRPCid** id, const char* enumName, int protoValue, uint32_t* lvEnumValue)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
-    }
-    auto metadata = (server.get())->FindEnumMetadata(std::string(enumName));
-    *(uint32_t*)lvEnumValue = metadata.get()->GetLVEnumValueFromProtoValue(protoValue);
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        auto metadata = (server.get())->FindEnumMetadata(std::string(enumName));
+        *(uint32_t*)lvEnumValue = metadata.get()->GetLVEnumValueFromProtoValue(protoValue);
 
-    return 0;
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t GetProtoValueFromLVEnumValue(grpc_labview::gRPCid** id, const char* enumName, int lvEnumValue, int32_t* protoValue)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
-    }
-    auto metadata = (server.get())->FindEnumMetadata(std::string(enumName));
-    *(int32_t*)protoValue = metadata.get()->GetProtoValueFromLVEnumValue(lvEnumValue);
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        auto metadata = (server.get())->FindEnumMetadata(std::string(enumName));
+        *(int32_t*)protoValue = metadata.get()->GetProtoValueFromLVEnumValue(lvEnumValue);
 
-    return 0;
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t CompleteMetadataRegistration(grpc_labview::gRPCid** id)
 {
-    auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
-    if (server == nullptr)
-    {
-        return -1;
+    try {
+        auto server = (*id)->CastTo<grpc_labview::MessageElementMetadataOwner>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
+        server->FinalizeMetadata();
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    server->FinalizeMetadata();
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t RegisterServerEvent(grpc_labview::gRPCid** id, const char* name, grpc_labview::LVUserEventRef* item, const char* requestMessageName, const char* responseMessageName)
 {
-    auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
-    if (server == nullptr)
-    {
-        return -1;
-    }
+    try {
+        auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
 
-    server->RegisterEvent(name, *item, requestMessageName, responseMessageName);
-    return 0;
+        server->RegisterEvent(name, *item, requestMessageName, responseMessageName);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t RegisterGenericMethodServerEvent(grpc_labview::gRPCid** id, grpc_labview::LVUserEventRef* item)
 {
-    auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
-    if (server == nullptr)
-    {
-        return -1;
-    }
+    try {
+        auto server = (*id)->CastTo<grpc_labview::LabVIEWgRPCServer>();
+        if (server == nullptr)
+        {
+            return -1;
+        }
 
-    server->RegisterGenericMethodEvent(*item);
-    return 0;
+        server->RegisterGenericMethodEvent(*item);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t GetRequestData(grpc_labview::gRPCid** id, int8_t* lvRequest)
 {
-    auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
-    if (data == nullptr)
-    {
-        return -1;
-    }
-    if (data->_call->IsCancelled())
-    {
-        return -(1000 + grpc::StatusCode::CANCELLED);
-    }
-    if (data->_call->IsActive() && data->_call->ReadNext())
-    {
-        try
+    try {
+        auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
+        if (data == nullptr)
         {
-            grpc_labview::ClusterDataCopier::CopyToCluster(*data->_request, lvRequest);
+            return -1;
         }
-        catch (grpc_labview::InvalidEnumValueException& e)
+        if (data->_call->IsCancelled())
         {
-            // Before returning, set the call to complete, otherwise the server hangs waiting for the call.
+            return -(1000 + grpc::StatusCode::CANCELLED);
+        }
+        if (data->_call->IsActive() && data->_call->ReadNext())
+        {
+            try
+            {
+                grpc_labview::ClusterDataCopier::CopyToCluster(*data->_request, lvRequest);
+            }
+            catch (const std::exception&)
+            {
+                // Before returning, set the call to complete, otherwise the server hangs waiting for the call.
+                data->_call->ReadComplete();
+                throw;
+            }
             data->_call->ReadComplete();
-            return e.code;
+            return 0;
         }
-        data->_call->ReadComplete();
-        return 0;
+        return -2;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return -2;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t SetResponseData(grpc_labview::gRPCid** id, int8_t* lvRequest)
 {
-    auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
-    if (data == nullptr)
-    {
-        return -1;
-    }
+    try {
+        auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
+        if (data == nullptr)
+        {
+            return -1;
+        }
 
-    if (data->_call->IsCancelled())
-    {
-        return -(1000 + grpc::StatusCode::CANCELLED);
-    }
+        if (data->_call->IsCancelled())
+        {
+            return -(1000 + grpc::StatusCode::CANCELLED);
+        }
 
-    try
-    {
         grpc_labview::ClusterDataCopier::CopyFromCluster(*data->_response, lvRequest);
-    }
-    catch (grpc_labview::InvalidEnumValueException& e)
-    {
-        return e.code;
-    }
 
-    if (!data->_call->IsActive() || !data->_call->Write())
-    {
-        return -2;
+        if (!data->_call->IsActive() || !data->_call->Write())
+        {
+            return -2;
+        }
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t CloseServerEvent(grpc_labview::gRPCid** id)
 {
-    auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
-    if (data == nullptr)
-    {
-        return -1;
-    }
+    try {
+        auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
+        if (data == nullptr)
+        {
+            return -1;
+        }
 
-    if (data->_call->IsCancelled())
-    {
-        return -(1000 + grpc::StatusCode::CANCELLED);
-    }
+        if (data->_call->IsCancelled())
+        {
+            return -(1000 + grpc::StatusCode::CANCELLED);
+        }
 
-    data->NotifyComplete();
-    data->_call->Finish();
-    grpc_labview::gPointerManager.UnregisterPointer(*id);
-    return 0;
+        data->NotifyComplete();
+        data->_call->Finish();
+        grpc_labview::gPointerManager.UnregisterPointer(*id);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t SetCallStatus(grpc_labview::gRPCid** id, int grpcErrorCode, const char* errorMessage)
 {
-    auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
-    if (data == nullptr)
-    {
-        return -1;
+    try {
+        auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
+        if (data == nullptr)
+        {
+            return -1;
+        }
+        data->_call->SetCallStatusError((grpc::StatusCode)grpcErrorCode, errorMessage);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    data->_call->SetCallStatusError((grpc::StatusCode)grpcErrorCode, errorMessage);
-    return 0;
 }
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t IsCancelled(grpc_labview::gRPCid** id)
 {
-    auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
-    if (data == nullptr)
-    {
-        return -1;
+    try {
+        auto data = (*id)->CastTo<grpc_labview::GenericMethodData>();
+        if (data == nullptr)
+        {
+            return -1;
+        }
+        return data->_call->IsCancelled();
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return data->_call->IsCancelled();
 }
 
 //---------------------------------------------------------------------
@@ -420,12 +485,16 @@ LIBRARY_EXPORT int32_t IsCancelled(grpc_labview::gRPCid** id)
    //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t SetLVRTModulePath(const char* modulePath)
 {
-    if (modulePath == nullptr)
-    {
-        return -1;
+    try {
+        if (modulePath == nullptr)
+        {
+            return -1;
+        }
+
+        grpc_labview::SetLVRTModulePath(modulePath);
+
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-
-    grpc_labview::SetLVRTModulePath(modulePath);
-
-    return 0;
 }

--- a/src/lv_proto_server_reflection_plugin.cc
+++ b/src/lv_proto_server_reflection_plugin.cc
@@ -65,7 +65,11 @@ namespace grpc_labview
 
     LIBRARY_EXPORT void DeserializeReflectionInfo(grpc_labview::LStrHandle serializedFileDescriptor)
     {
-        std::string serializedDescriptorStr = grpc_labview::GetLVString(serializedFileDescriptor);
-        grpc_labview::ProtoDescriptorString::getInstance()->setDescriptor(serializedDescriptorStr);
+        try {
+            std::string serializedDescriptorStr = grpc_labview::GetLVString(serializedFileDescriptor);
+            grpc_labview::ProtoDescriptorString::getInstance()->setDescriptor(serializedDescriptorStr);
+        } catch (const std::exception&) {
+            // Ignore errors
+        }
     }
 }

--- a/src/unpacked_fields.cc
+++ b/src/unpacked_fields.cc
@@ -215,18 +215,22 @@ namespace grpc_labview
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t UnpackFieldsFromBuffer(grpc_labview::LV1DArrayHandle lvBuffer, grpc_labview::gRPCid** unpackedFieldsRef)
 {
-    char* elements = (*lvBuffer)->bytes<char>();
-    std::string buffer(elements, (*lvBuffer)->cnt);
+    try {
+        char* elements = (*lvBuffer)->bytes<char>();
+        std::string buffer(elements, (*lvBuffer)->cnt);
 
-    auto message = new grpc_labview::LVMessage(nullptr);
-    if (message->ParseFromString(buffer))
-    {
-        auto fields = new grpc_labview::UnpackedFields(message);
-        grpc_labview::gPointerManager.RegisterPointer(fields);
-        *unpackedFieldsRef = fields;
-        return 0;
+        auto message = new grpc_labview::LVMessage(nullptr);
+        if (message->ParseFromString(buffer))
+        {
+            auto fields = new grpc_labview::UnpackedFields(message);
+            grpc_labview::gPointerManager.RegisterPointer(fields);
+            *unpackedFieldsRef = fields;
+            return 0;
+        }
+        return -2;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
     }
-    return -2;
 }
 
 //---------------------------------------------------------------------
@@ -240,19 +244,23 @@ LIBRARY_EXPORT int32_t UnpackFieldsFromAny(grpc_labview::AnyCluster* anyCluster,
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t GetUnpackedField(grpc_labview::gRPCid* id, int protobufIndex, grpc_labview::LVMessageMetadataType valueType, int isRepeated, int8_t* buffer)
 {
-    if (id == nullptr)
-    {
-        return -1;
-    }
+    try {
+        if (id == nullptr)
+        {
+            return -1;
+        }
 
-    auto unpackedFields = id->CastTo<grpc_labview::UnpackedFields>();
-    if (!unpackedFields)
-    {
-        return -1;
-    }
+        auto unpackedFields = id->CastTo<grpc_labview::UnpackedFields>();
+        if (!unpackedFields)
+        {
+            return -1;
+        }
 
-    unpackedFields->GetField(protobufIndex, valueType, isRepeated, buffer);
-    return 0;
+        unpackedFields->GetField(protobufIndex, valueType, isRepeated, buffer);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }
 
 //---------------------------------------------------------------------
@@ -266,6 +274,10 @@ LIBRARY_EXPORT int32_t GetUnpackedMessageField(grpc_labview::gRPCid* id, int pro
 //---------------------------------------------------------------------
 LIBRARY_EXPORT int32_t FreeUnpackedFields(grpc_labview::gRPCid* id)
 {
-    grpc_labview::gPointerManager.UnregisterPointer(id);
-    return 0;
+    try {
+        grpc_labview::gPointerManager.UnregisterPointer(id);
+        return 0;
+    } catch (const std::exception&) {
+        return grpc_labview::TranslateException();
+    }
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update all exported library functions to catch and translate C++ exceptions.

`exceptions.h`:
- Add `GrpcException` and `LabVIEWException` classes
- Change `InvalidEnumValueException` to subclass `LabVIEWException`
- Add `TranslateException` function, which translates the current exception to an error code to return to LabVIEW. It also logs the exception message in debug builds.
- Add `SetErrorMessage` function, which sets an `LStrHandle* errorMessage` out-parameter and ignores errors.

Update functions marked `LIBRARY_EXPORT`:
- Add a try/catch block around the entire function, unless it is a simple forwarding function
- In the catch block, call `TranslateException` (and `SetErrorMessage` if appropriate)
- Remove existing try/catch blocks, except when needed for cleanup purposes

### Why should this Pull Request be merged?

Closes #438 
Partially implements #437 

### What testing has been done?

Ran tests on LabVIEW 2019.
Ran code generator on `helloworld.proto`.