### PR TITLE
Cache feature toggles

### DIFF
--- a/src/feature_toggles.cc
+++ b/src/feature_toggles.cc
@@ -16,7 +16,7 @@ namespace grpc_labview {
     // If filePath contains a path, that specific configuration file will be used
     //   This filePath can contain either a filename (which is assumed to be in the
     //   same directory as this shared library) or an absolute path.
-    // 
+    //
     // Note that all features will be re-initialized using the new file.
     void FeatureConfig::ReloadFeaturesFromFile(const std::string& filePath) {
         // Clear all features from the map to re-initialize
@@ -27,8 +27,11 @@ namespace grpc_labview {
         ReadFeatureFile(filePath);
 
         //TODO: remove this post fixing LVMessageEfficient to let enable feature. See issue: #433
-        if (featureFlags.find("data_EfficientMessageCopy") != featureFlags.end())
-            featureFlags["data_EfficientMessageCopy"] = false;
+        if (featureFlags.find(kFeatureEfficientMessageCopy) != featureFlags.end())
+            featureFlags[kFeatureEfficientMessageCopy] = false;
+
+        efficientMessageCopy = IsFeatureEnabled(kFeatureEfficientMessageCopy);
+        useOccurrence = IsFeatureEnabled(kFeatureUseOccurrence);
     }
 
     // Function to check if a feature is enabled
@@ -40,21 +43,21 @@ namespace grpc_labview {
     // Function to read feature configurations from an INI file
     void FeatureConfig::ReadFeatureFile(const std::string& filePath) {
         std::filesystem::path configFilePath = filePath;
-        
+
         if (configFilePath.empty()) {
             // If no filepath passed into this function, use the default
             // configuration file path.
             configFilePath = GetDefaultConfigPath();
         }
         else if (configFilePath.is_relative()) {
-            // If a relative path (ie, just a filename) was passed in, 
+            // If a relative path (ie, just a filename) was passed in,
             // assume that the is in the current directory
             configFilePath = GetFolderContainingDLL() / configFilePath;
         }
 
         // This flag is used to indicate that the default/given feature file was found/used.
         // Reset this flag to set to true after the file is successfully opened
-        featureFlags["featureFileFound"] = false;
+        featureFlags[kFeatureFileFound] = false;
 
         std::ifstream configFile(configFilePath.string());
         if (!configFile.is_open()) {
@@ -64,7 +67,7 @@ namespace grpc_labview {
         // Set this feature to true once the file is opened.  Note that this feature flag
         // does not indicate if the file was successfully parsed; only that it was found
         // and opened.
-        featureFlags["featureFileFound"] = true;
+        featureFlags[kFeatureFileFound] = true;
 
         std::string line;
         std::string currentSection; // For handling INI sections
@@ -106,7 +109,7 @@ namespace grpc_labview {
         std::filesystem::path configPath = GetFolderContainingDLL();
 
         // Add the default config filename to path
-        configPath /= defaultConfigFileName;  
+        configPath /= defaultConfigFileName;
         return configPath;
     }
 }

--- a/src/feature_toggles.h
+++ b/src/feature_toggles.h
@@ -4,6 +4,10 @@
 
 
 namespace grpc_labview {
+    static constexpr const char* kFeatureFileFound = "featureFileFound";
+    static constexpr const char* kFeatureEfficientMessageCopy = "data_EfficientMessageCopy";
+    static constexpr const char* kFeatureUseOccurrence = "data_useOccurrence";
+
     class FeatureConfig {
     public:
         // Singleton instance
@@ -18,20 +22,30 @@ namespace grpc_labview {
         // Function to check if a feature is enabled
         bool IsFeatureEnabled(const std::string& featureName) const;
 
+        // Functions to check specific feature toggles
+        bool IsEfficientMessageCopyEnabled() const { return efficientMessageCopy; }
+        bool IsUseOccurrenceEnabled() const { return useOccurrence; }
+
     private:
         std::unordered_map<std::string, bool> featureFlags;
         const std::string defaultConfigFileName = "feature_config.ini";
+
+        bool efficientMessageCopy;
+        bool useOccurrence;
 
         // This stores the default feature configuration.
         // During ReloadFeaturesFromFile(), this configuration is always applied first prior to reading the
         // features configuration file
         void ApplyDefaultFeatures() {
-            featureFlags["featureFileFound"] = false;  // Used to indicate if the feature file was found/used during initialization
-            featureFlags["data_EfficientMessageCopy"] = false;
-            featureFlags["data_useOccurrence"] = true;
+            featureFlags[kFeatureFileFound] = false;  // Used to indicate if the feature file was found/used during initialization
+            featureFlags[kFeatureEfficientMessageCopy] = false;
+            featureFlags[kFeatureUseOccurrence] = true;
         }
-        
-        FeatureConfig() {
+
+        FeatureConfig() :
+            efficientMessageCopy(false),
+            useOccurrence(false)
+        {
             // Read the default configuration file during initialization
             ReloadFeaturesFromFile("");
         }

--- a/src/grpc_client.cc
+++ b/src/grpc_client.cc
@@ -367,7 +367,7 @@ LIBRARY_EXPORT int32_t ClientUnaryCall2(
         clientCall->_client = client;
         clientCall->_methodName = methodName;
 
-        if (featureConfig.IsFeatureEnabled("data_useOccurrence"))
+        if (featureConfig.IsUseOccurrenceEnabled())
         {
             clientCall->_occurrence = *occurrence;
         }
@@ -376,7 +376,7 @@ LIBRARY_EXPORT int32_t ClientUnaryCall2(
         }
         clientCall->_context = clientContext;
 
-        if (featureConfig.IsFeatureEnabled("data_EfficientMessageCopy") && responseCluster != nullptr)
+        if (featureConfig.IsEfficientMessageCopyEnabled() && responseCluster != nullptr)
         {
             clientCall->_useLVEfficientMessage = true;
         }
@@ -676,7 +676,7 @@ LIBRARY_EXPORT int32_t ClientBeginReadFromStream(grpc_labview::gRPCid* callId, g
         auto featureConfig = grpc_labview::FeatureConfig::getInstance();
 
         grpc_labview::MagicCookie occurrence = 0;
-        if (featureConfig.IsFeatureEnabled("data_useOccurrence"))
+        if (featureConfig.IsUseOccurrenceEnabled())
         {
             occurrence = *occurrencePtr;
         }
@@ -831,7 +831,7 @@ LIBRARY_EXPORT int32_t ClientCompleteClientStreamingCall(grpc_labview::gRPCid* c
         }
         auto featureConfig = grpc_labview::FeatureConfig::getInstance();
 
-        if (featureConfig.IsFeatureEnabled("data_useOccurrence")) {
+        if (featureConfig.IsUseOccurrenceEnabled()) {
             call->_occurrence = *occurrencePtr;
         }
         else {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Cache feature toggles as `bool` member variables.

Single-source feature toggle names.

### Why should this Pull Request be merged?

Checking a feature toggle should not cause a performance regression.

In #471, I am adding feature toggle checks to frequently-called functions such as `SetLVString` and `GetLVString`. I do not want these checks to introduce additional memory allocations. The feature toggle names are long enough to defeat the small string optimization in Microsoft's implementation of `std::string`.

### What testing has been done?

Ran `tests/run_tests.py` and `tests/New_ATS/pylib/run_tests.py` on LabVIEW 2019.

Created a `feature_config.ini` and used Visual Studio to verify that the new member variables are set correctly.