### PR TITLE
Signal LV events for the server when connection for RPC is established

### DIFF
--- a/src/grpc_interop.cc
+++ b/src/grpc_interop.cc
@@ -374,17 +374,7 @@ LIBRARY_EXPORT int32_t GetRequestData(grpc_labview::gRPCid** id, int8_t* lvReque
         }
         if (data->_call->IsActive() && data->_call->ReadNext())
         {
-            try
-            {
-                grpc_labview::ClusterDataCopier::CopyToCluster(*data->_request, lvRequest);
-            }
-            catch (const std::exception&)
-            {
-                // Before returning, set the call to complete, otherwise the server hangs waiting for the call.
-                data->_call->ReadComplete();
-                throw;
-            }
-            data->_call->ReadComplete();
+            grpc_labview::ClusterDataCopier::CopyToCluster(*data->_request, lvRequest);
             return 0;
         }
         // Check if a custom error status was set via SetCallStatus

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -155,7 +155,6 @@ namespace grpc_labview
         bool IsCancelled();
         bool IsActive();
         bool ReadNext();
-        void ReadComplete();
         void SetCallStatusError(std::string errorMessage);
         void SetCallStatusError(grpc::StatusCode statusCode, std::string errorMessage);
         grpc::StatusCode GetCallStatusCode();
@@ -174,14 +173,12 @@ namespace grpc_labview
         std::shared_ptr<LVMessage> _request;
         std::shared_ptr<LVMessage> _response;
 
-        bool _requestDataReady;
-
         enum class CallStatus
         {
             Create,
-            Read,
-            Writing,
-            Process,
+            WaitingForConnection,
+            WritingResponse,
+            Connected,
             PendingFinish,
             Finish
         };


### PR DESCRIPTION
# Description
Signal LV events for the server when connection for RPC is established rather than waiting until the first request message is read. This provides more flexibility in the server implementation for a few different scenarios:
- The server needs to perform setup operations before receiving data
- The server needs to acknowledge the connection immediately
- The application requires low-latency connection awareness
- A bidirectional RPC wants to send response data to the client before receiving any request data

# Implementation / Design
- LV event for the RPC is now signaled when the connection for the RPC is established rather than when the first request message is received. Request messages are now only read from the stream when explicit API calls are made from the user's implementation of the RPC on the server. We no longer read the first request message in response to events from the server's completion queue.
- Updated some of the internal state machine state names for readability.
- Deleted `CallData::ReadComplete`. This is no longer needed as all reads are now performed within `ReadNext`.

# Testing
I manually tested using unary, client streaming, server streaming, and bidirectional RPCs using the example route guide service. I also spot tested using some existing measurement services.