### PR TITLE
Update python build to support Python 3.12 and above

### DIFF
--- a/build-it/build.py
+++ b/build-it/build.py
@@ -243,9 +243,7 @@ def copy_tree(source_dir, dest_dir):
     source_dir: source directory file path
     dest_dir: destination directory file path
     '''
-    if os.path.exists(dest_dir):
-        su.rmtree(dest_dir)
-    su.copytree(source_dir, dest_dir)
+    su.copytree(source_dir, dest_dir, dirs_exist_ok=True)
     return
 
 

--- a/build-it/build.py
+++ b/build-it/build.py
@@ -1,7 +1,5 @@
 import argparse
-import distutils
-import distutils.dir_util
-import distutils.file_util
+import shutil as su
 import os
 import subprocess
 
@@ -72,7 +70,7 @@ class LVgRPCBuilder:
     def cpp_build(self, args):
         cpp_build_directory = os.path.join(self.root_directory, "build")
         if os.path.exists(cpp_build_directory):
-            distutils.dir_util.remove_tree(cpp_build_directory)
+            su.rmtree(cpp_build_directory, ignore_errors=True)
         os.makedirs(cpp_build_directory)
         os.chdir(cpp_build_directory)
 
@@ -81,13 +79,11 @@ class LVgRPCBuilder:
 
     def copy_binaries_all_targets(self, args):
         server_dll_source = os.path.join(args.pathToBinaries, "LabVIEW gRPC Server")
-        distutils.dir_util.copy_tree(server_dll_source, self.server_binary_destination)
+        copy_tree(server_dll_source, self.server_binary_destination)
         generator_dll_source = os.path.join(
             args.pathToBinaries, "LabVIEW gRPC Generator"
         )
-        distutils.dir_util.copy_tree(
-            generator_dll_source, self.generator_binary_destination
-        )
+        copy_tree(generator_dll_source, self.generator_binary_destination)
 
     def copy_binaries_for_target(self, args):
         server_dll_source = os.path.join(
@@ -98,7 +94,7 @@ class LVgRPCBuilder:
         )
         if not os.path.exists(server_dll_destination):
             os.makedirs(server_dll_destination)
-        distutils.file_util.copy_file(server_dll_source, server_dll_destination)
+        su.copy2(server_dll_source, server_dll_destination)
 
         generator_dll_source = os.path.join(
             self.root_directory, "build", "Release", "labview_grpc_generator.dll"
@@ -108,7 +104,7 @@ class LVgRPCBuilder:
         )
         if not os.path.exists(generator_dll_destination):
             os.makedirs(generator_dll_destination)
-        distutils.file_util.copy_file(generator_dll_source, generator_dll_destination)
+        su.copy2(generator_dll_source, generator_dll_destination)
 
     def copy_built_binaries(self, args):
         if args.target == "All":
@@ -182,7 +178,7 @@ class LVgRPCBuilder:
 
         # Before building vipkgs, ensure the output directory is empty
         if os.path.exists(build_output_path):
-            distutils.dir_util.remove_tree(build_output_path)
+            su.rmtree(build_output_path, ignore_errors=True)
         os.makedirs(build_output_path)
 
         # Build the packages using LabVIEWCLI
@@ -239,6 +235,18 @@ def read_version_from_file(version_file_path):
             if line.startswith("version="):
                 return line.split("=", 1)[1]
     raise Exception("version= key not found in VERSION file")
+
+def copy_tree(source_dir, dest_dir):
+    '''
+    Recursively copy one directory to another, maintaining file attributes
+
+    source_dir: source directory file path
+    dest_dir: destination directory file path
+    '''
+    if os.path.exists(dest_dir):
+        su.rmtree(dest_dir)
+    su.copytree(source_dir, dest_dir)
+    return
 
 
 def main():


### PR DESCRIPTION
**Purpose:** The `build.py` script uses the Python `distutils` package. This package was deprecated in Python 3.10 and removed in Python 3.12. As a result, `build.py` does not work with Python versions above 3.11. Python 3.9 and previous is end-of-life and no longer maintained. Python 3.10 will go end-of-life in October 2026. Python 3.11 will go end-of-life in October 2027. Current release is 3.14. 
**Changes Made:** All `distutils` functions were replaced with equivalent `shutil` functions. Note that the `shutil` functions have the same issues the `distutils` functions did, but enumerate them in the readme. Better functionality could probably be derived using OS specific functions, but the original worked well enough, so it is expected that this will work as well.
**Related Issues:** #395
**Testing:** The revised script was used to generate packages of the [Fix code generation so that it no longer errors when generating on top of previously generated code](https://github.com/ni/grpc-labview/tree/users/jreding/FixCodeGenOverExistingLibrary) branch as of 3 June 2026. This was done twice to ensure no directory copy issues. The result was then successfully used to generate client and server code.